### PR TITLE
domain migration: houseofcwk.com → cwkexperience.com

### DIFF
--- a/.claude/skills/cwk-page-edit/SKILL.md
+++ b/.claude/skills/cwk-page-edit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cwk-page-edit
-description: Standard workflow for editing pages on the CWK website (case studies, about, journey, etc.). Use when the user asks to update copy, swap an image, add/remove a section, change a stat, restructure a body, or apply edits annotated on a screenshot. Triggers: "edit page", "update case study", "let's work on /about", "let's edit /case-studies/<slug>", any annotated screenshot of a page on houseofcwk.com.
+description: Standard workflow for editing pages on the CWK website (case studies, about, journey, etc.). Use when the user asks to update copy, swap an image, add/remove a section, change a stat, restructure a body, or apply edits annotated on a screenshot. Triggers: "edit page", "update case study", "let's work on /about", "let's edit /case-studies/<slug>", any annotated screenshot of a page on cwkexperience.com.
 ---
 
 # CWK page-edit workflow

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -4,7 +4,7 @@
 # Start local dev with: npx wrangler pages dev dist --kv WAITLIST
 
 RESEND_API=re_...
-FROM_EMAIL=waitlist@houseofcwk.com
+FROM_EMAIL=hello@cwkexperience.com
 FROM_NAME=CWK. Experience
-REPLY_TO_EMAIL=kris@houseofcwk.com
+REPLY_TO_EMAIL=hello@cwkexperience.com
 REPLY_TO_NAME=Kris San

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # ── Public (browser-exposed) ────────────────────────────────────────────────
-PUBLIC_SITE_URL=https://houseofcwk.com
+PUBLIC_SITE_URL=https://cwkexperience.com
 PUBLIC_CF_ANALYTICS_TOKEN=
 # Google Tag Manager — omit to disable tracking (local dev, previews)
 PUBLIC_GTM_ID=
@@ -15,7 +15,7 @@ PUBLIC_GTM_ID=
 # wrangler pages secret put REPLY_TO_EMAIL --project-name=houseofcwk
 # wrangler pages secret put REPLY_TO_NAME  --project-name=houseofcwk
 RESEND_API=re_...
-FROM_EMAIL=waitlist@houseofcwk.com
+FROM_EMAIL=hello@cwkexperience.com
 FROM_NAME=CWK. Experience
-REPLY_TO_EMAIL=kris@houseofcwk.com
+REPLY_TO_EMAIL=hello@cwkexperience.com
 REPLY_TO_NAME=Kris San

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,9 +34,9 @@ jobs:
       # reproducible if Cloudflare-injected Pages env is ever absent.
       PUBLIC_SANITY_PROJECT_ID: 3fsa3jok
       PUBLIC_SANITY_DATASET: production
-      PUBLIC_API_BASE_URL: https://api.houseofcwk.com
+      PUBLIC_API_BASE_URL: https://api.cwkexperience.com
       PUBLIC_GTM_ID: GTM-MVJ9VXS5
-      PUBLIC_SITE_URL: https://houseofcwk.com
+      PUBLIC_SITE_URL: https://cwkexperience.com
 
     steps:
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - **Type:** Static marketing/product site
 - **Tagline:** "The sports agent for entrepreneurs."
 - **Philosophy:** Build. Learn. Earn. Play.
-- **Target URL:** houseofcwk.com (Cloudflare Pages — project: houseofcwk)
+- **Target URL:** cwkexperience.com (Cloudflare Pages — project: houseofcwk)
 - **Reference site:** cwkexperience.com (old site on page builder — used as content/design source only, not the deploy target)
 
 ## Tech Stack

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## What We're Building
 
-A production-grade marketing and product website for **CWK. Experience** — deployed to **houseofcwk.com** (Cloudflare Pages project: `houseofcwk`).
+A production-grade marketing and product website for **CWK. Experience** — deployed to **cwkexperience.com** (Cloudflare Pages project: `houseofcwk`).
 
 Replaces the old site hosted on a page builder at [cwkexperience.com](https://cwkexperience.com/) — that domain is used as a **content and design reference only**, not as the deploy target.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Deploy to Cloudflare Pages](https://github.com/houseofcwk/cwk-plos-site/actions/workflows/deploy.yml/badge.svg)](https://github.com/houseofcwk/cwk-plos-site/actions/workflows/deploy.yml)
 [![Astro](https://img.shields.io/badge/Astro-5.6-FF5D01?logo=astro&logoColor=white)](https://astro.build)
-[![Cloudflare Pages](https://img.shields.io/badge/Cloudflare_Pages-live-F38020?logo=cloudflare&logoColor=white)](https://houseofcwk.com)
+[![Cloudflare Pages](https://img.shields.io/badge/Cloudflare_Pages-live-F38020?logo=cloudflare&logoColor=white)](https://cwkexperience.com)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)](https://react.dev)
 
@@ -10,7 +10,7 @@
 
 The official product website for **CWK. Experience** — long-term business management for high-performing entrepreneurs ($150K–$5M). Built on Astro, deployed globally via Cloudflare Pages.
 
-**Live site:** [houseofcwk.com](https://houseofcwk.com)
+**Live site:** [cwkexperience.com](https://cwkexperience.com)
 
 ---
 
@@ -18,7 +18,7 @@ The official product website for **CWK. Experience** — long-term business mana
 
 | Environment | URL | Trigger |
 |-------------|-----|---------|
-| Production | [houseofcwk.com](https://houseofcwk.com) | Push to `main` |
+| Production | [cwkexperience.com](https://cwkexperience.com) | Push to `main` |
 | Preview | `*.houseofcwk.pages.dev` | Pull request |
 
 Deploys are automatic via GitHub Actions → `cloudflare/wrangler-action@v3`. Build time is typically under 30 seconds.
@@ -99,15 +99,15 @@ docs/
 ## API
 
 All HTTP APIs are served by a single Cloudflare Worker (`cwk-api-prod`)
-bound to `api.houseofcwk.com`. Source lives at [`workers/api/`](./workers/api/);
+bound to `api.cwkexperience.com`. Source lives at [`workers/api/`](./workers/api/);
 see [`workers/api/README.md`](./workers/api/README.md) for the endpoint map,
 deploy steps, and secrets.
 
 | Endpoint                                | Handler                                              |
 |-----------------------------------------|------------------------------------------------------|
-| `POST https://api.houseofcwk.com/waitlist` | [handlers/waitlist.ts](./workers/api/src/handlers/waitlist.ts) |
-| `POST https://api.houseofcwk.com/contact`  | [handlers/contact.ts](./workers/api/src/handlers/contact.ts)   |
-| `GET  https://api.houseofcwk.com/healthz`  | `{ "ok": true }`                                     |
+| `POST https://api.cwkexperience.com/waitlist` | [handlers/waitlist.ts](./workers/api/src/handlers/waitlist.ts) |
+| `POST https://api.cwkexperience.com/contact`  | [handlers/contact.ts](./workers/api/src/handlers/contact.ts)   |
+| `GET  https://api.cwkexperience.com/healthz`  | `{ "ok": true }`                                     |
 
 ### Waitlist (`POST /waitlist`)
 
@@ -140,9 +140,9 @@ Copy `.env.example` → `.env` for public vars. Copy `.dev.vars.example` → `.d
 | `PUBLIC_SITE_URL` | `.env` / CF Pages | Canonical site URL |
 | `PUBLIC_CF_ANALYTICS_TOKEN` | `.env` / CF Pages | Web Analytics token |
 | `RESEND_API` | CF Pages secret | Resend API key |
-| `FROM_EMAIL` | CF Pages secret | `waitlist@houseofcwk.com` |
+| `FROM_EMAIL` | CF Pages secret | `waitlist@cwkexperience.com` |
 | `FROM_NAME` | CF Pages secret | Sender display name |
-| `REPLY_TO_EMAIL` | CF Pages secret | `kris@houseofcwk.com` |
+| `REPLY_TO_EMAIL` | CF Pages secret | `kris@cwkexperience.com` |
 | `REPLY_TO_NAME` | CF Pages secret | Reply-to display name |
 | `WAITLIST` | CF Pages KV binding | KV namespace (not an env var) |
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,7 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://houseofcwk.com',
+  site: 'https://cwkexperience.com',
   output: 'static',
   integrations: [
     react(),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — CWK PLOS Site
 
-> `cwk-plos-site` · Astro 5 · Cloudflare Pages · houseofcwk.com
+> `cwk-plos-site` · Astro 5 · Cloudflare Pages · cwkexperience.com
 
 > **Note:** The diagrams below were drawn pre-Sanity (when the waitlist ran as
 > an Astro API route under `_worker.js` SSR). Current truth:
@@ -9,13 +9,13 @@
 >   (project `3fsa3jok`, dataset `production`).
 > - APIs live in a **single consolidated Cloudflare Worker** at
 >   [`workers/api/`](../workers/api/) (`cwk-api-prod`), bound to
->   `api.houseofcwk.com`. Handlers: `POST /waitlist`, `POST /contact`.
+>   `api.cwkexperience.com`. Handlers: `POST /waitlist`, `POST /contact`.
 > - The `KV: WAITLIST` namespace is reused byte-for-byte; `CONTACTS` +
 >   `RATE_LIMIT` KV are bound to the same worker.
 >
 > The sequence/structure diagrams below still capture the request shape
 > correctly, but paths/bindings should be read as
-> `api.houseofcwk.com/{waitlist,contact}` rather than `/api/waitlist`.
+> `api.cwkexperience.com/{waitlist,contact}` rather than `/api/waitlist`.
 
 ---
 
@@ -28,7 +28,7 @@ graph TB
     end
 
     subgraph CLOUDFLARE["Cloudflare Edge Network"]
-        DNS["DNS<br/>houseofcwk.com"]
+        DNS["DNS<br/>cwkexperience.com"]
         WAF["WAF / DDoS"]
         Pages["Cloudflare Pages<br/>project: houseofcwk"]
         Analytics["CF Web Analytics"]
@@ -37,7 +37,7 @@ graph TB
             MW["Middleware<br/>Basic Auth Gate"]
             Router["Astro Router"]
             SSR["SSR Pages"]
-            API["API Routes<br/>api.houseofcwk.com/{waitlist,contact}"]
+            API["API Routes<br/>api.cwkexperience.com/{waitlist,contact}"]
         end
 
         subgraph STORAGE["Cloudflare Storage"]
@@ -73,7 +73,7 @@ sequenceDiagram
     participant CF as Cloudflare Edge
     participant MW as Middleware
     participant R as Astro Router
-    participant API as api.houseofcwk.com/{waitlist,contact}
+    participant API as api.cwkexperience.com/{waitlist,contact}
     participant KV as KV Store
     participant RS as Resend
 
@@ -86,7 +86,7 @@ sequenceDiagram
     R->>B: SSR HTML response
 
     Note over B,RS: Waitlist Submission
-    B->>CF: POST api.houseofcwk.com/{waitlist,contact} {email}
+    B->>CF: POST api.cwkexperience.com/{waitlist,contact} {email}
     CF->>MW: Route request
     MW->>API: /api/* bypass auth
     API->>KV: WAITLIST.get(email)
@@ -135,7 +135,7 @@ graph LR
 
 ```mermaid
 graph TD
-    subgraph SITE["houseofcwk.com"]
+    subgraph SITE["cwkexperience.com"]
         HOME["/ <br/>Homepage"]
         ABOUT["About"]
         AB_IDX["/about"]
@@ -158,7 +158,7 @@ graph TD
         PRIVACY["/privacy"]
         TERMS["/terms"]
         ERR404["/404"]
-        API_WL["api.houseofcwk.com/{waitlist,contact}<br/>POST · OPTIONS"]
+        API_WL["api.cwkexperience.com/{waitlist,contact}<br/>POST · OPTIONS"]
     end
 
     HOME --- ABOUT
@@ -249,7 +249,7 @@ graph TB
 
     subgraph CF_ACCOUNT["Cloudflare Account<br/>ID: 1e48d0c..."]
         subgraph CF_PAGES["Cloudflare Pages<br/>project: houseofcwk"]
-            PROD_DEPLOY["Production<br/>main branch<br/>houseofcwk.com"]
+            PROD_DEPLOY["Production<br/>main branch<br/>cwkexperience.com"]
             PREVIEW_DEPLOY["Preview<br/>PR branches<br/>*.houseofcwk.pages.dev"]
         end
 
@@ -260,7 +260,7 @@ graph TB
             KV_SS_PREV["SESSION (preview)<br/>db599f73..."]
         end
 
-        CF_DNS["Cloudflare DNS<br/>houseofcwk.com"]
+        CF_DNS["Cloudflare DNS<br/>cwkexperience.com"]
         CF_WAF["WAF + DDoS Protection"]
         CF_ANA["Web Analytics"]
     end
@@ -275,12 +275,12 @@ graph TB
     subgraph ENV_VARS["Environment Variables"]
         direction LR
         EV_PREV["Preview<br/>ENVIRONMENT=preview<br/>PUBLIC_SITE_URL=*.pages.dev"]
-        EV_PROD["Production<br/>ENVIRONMENT=production<br/>PUBLIC_SITE_URL=houseofcwk.com"]
+        EV_PROD["Production<br/>ENVIRONMENT=production<br/>PUBLIC_SITE_URL=cwkexperience.com"]
     end
 
     subgraph EXTERNAL_SVC["External Services"]
         RESEND_SVC["Resend<br/>Transactional Email API"]
-        DOMAIN["houseofcwk.com<br/>Custom Domain"]
+        DOMAIN["cwkexperience.com<br/>Custom Domain"]
     end
 
     REPO -->|"push main"| GHA
@@ -357,8 +357,8 @@ graph LR
 | Variable | Preview | Production |
 |----------|---------|------------|
 | `ENVIRONMENT` | `preview` | `production` |
-| `PUBLIC_SITE_URL` | `https://houseofcwk.pages.dev` | `https://houseofcwk.com` |
-| `FROM_EMAIL` | `hello@houseofcwk.com` | `hello@houseofcwk.com` |
+| `PUBLIC_SITE_URL` | `https://houseofcwk.pages.dev` | `https://cwkexperience.com` |
+| `FROM_EMAIL` | `hello@cwkexperience.com` | `hello@cwkexperience.com` |
 | `FROM_NAME` | `CWK. Experience` | `CWK. Experience` |
 | `REPLY_TO_EMAIL` | `hello@cwkexperience.com` | `hello@cwkexperience.com` |
 | `REPLY_TO_NAME` | `Kris San, CWK.` | `Kris San, CWK.` |
@@ -378,7 +378,7 @@ graph LR
 ```mermaid
 graph TD
     subgraph PLATFORM["houseofcwk/platform (monorepo)"]
-        PLOS["projects/cwk-plos-site<br/>Astro · Cloudflare Pages<br/>houseofcwk.com"]
+        PLOS["projects/cwk-plos-site<br/>Astro · Cloudflare Pages<br/>cwkexperience.com"]
         EXP["projects/cwk-exp-main<br/>(submodule · read-only)<br/>Agent+ Dashboard · Vercel"]
         GH_CFG[".github/<br/>project-config.json"]
     end

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -48,7 +48,7 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://houseofcwk.com',
+  site: 'https://cwkexperience.com',
   output: 'static',
   adapter: cloudflare(),
   integrations: [
@@ -100,7 +100,7 @@ npm run dev         # http://localhost:4321
 
 | Variable | Value |
 |----------|-------|
-| `PUBLIC_SITE_URL` | `https://houseofcwk.com` |
+| `PUBLIC_SITE_URL` | `https://cwkexperience.com` |
 | `PUBLIC_CF_ANALYTICS_TOKEN` | *(from Cloudflare Web Analytics)* |
 | `NODE_VERSION` | `20` |
 
@@ -119,20 +119,20 @@ npx wrangler pages deploy dist --project-name=cwk-plos-site
 
 ## Custom Domain Setup
 
-### Connect `houseofcwk.com`
+### Connect `cwkexperience.com`
 
 1. In Cloudflare Pages project settings → **Custom domains**
-2. Add `houseofcwk.com` and `www.houseofcwk.com`
+2. Add `cwkexperience.com` and `www.cwkexperience.com`
 3. If the domain's DNS is already on Cloudflare, CNAME records are auto-configured
 4. If not, add these DNS records:
 
 ```
-CNAME   houseofcwk.com       cwk-plos-site.pages.dev
+CNAME   cwkexperience.com       cwk-plos-site.pages.dev
 CNAME   www                  cwk-plos-site.pages.dev
 ```
 
 5. Enable **Always Use HTTPS** in Cloudflare dashboard
-6. Set up a page rule or redirect: `www.houseofcwk.com/*` → `https://houseofcwk.com/$1` (301)
+6. Set up a page rule or redirect: `www.cwkexperience.com/*` → `https://cwkexperience.com/$1` (301)
 
 ---
 
@@ -233,7 +233,7 @@ Before going live:
 Go to https://resend.com and create an account.
 
 ### 2. Verify your sending domain
-In Resend dashboard: Domains → Add domain → `houseofcwk.com`
+In Resend dashboard: Domains → Add domain → `cwkexperience.com`
 Add the DNS records Resend provides (SPF, DKIM, DMARC).
 
 ### 3. Create an API key
@@ -242,7 +242,7 @@ Save the key — you will only see it once.
 
 ### 4. Set secrets on the API Worker
 APIs now live in `workers/api/` (a single consolidated worker —
-`cwk-api-prod` — at `api.houseofcwk.com`). Only `RESEND_API` is a secret;
+`cwk-api-prod` — at `api.cwkexperience.com`). Only `RESEND_API` is a secret;
 the rest are plain vars in `workers/api/wrangler.toml`.
 
 ```bash

--- a/docs/SANITY_RUNBOOK.md
+++ b/docs/SANITY_RUNBOOK.md
@@ -9,7 +9,7 @@ One-time setup actions to take outside the codebase. Run in this order.
 - Project ID: `3fsa3jok`
 - Organization ID: `ocjx5u09p`
 - Dataset: `production`
-- Studio (embedded): https://houseofcwk.com/studio
+- Studio (embedded): https://cwkexperience.com/studio
 
 Open https://www.sanity.io/manage and verify you can see the project.
 
@@ -20,7 +20,7 @@ Open https://www.sanity.io/manage and verify you can see the project.
 Add (no credentials needed):
 
 - `http://localhost:4321`
-- `https://houseofcwk.com`
+- `https://cwkexperience.com`
 - `https://houseofcwk.pages.dev`
 
 ---
@@ -44,20 +44,20 @@ npx wrangler secret put RESEND_API --env production
 npx wrangler secret put TURNSTILE_SECRET --env production   # if using Turnstile
 npx wrangler secret put HASH_SALT        --env production   # salt for IP hashing
 
-# 4. Bind the api.houseofcwk.com custom domain.
+# 4. Bind the api.cwkexperience.com custom domain.
 #    The first deploy registers the worker; the routes in wrangler.toml
 #    declare custom_domain=true so Cloudflare provisions the cert.
 npx wrangler deploy --env production
 
 # 5. Smoke-test:
-curl https://api.houseofcwk.com/healthz         # → {"ok":true}
-curl https://api.houseofcwk.com/contact/healthz # → {"ok":true}
-curl -X POST https://api.houseofcwk.com/waitlist \
+curl https://api.cwkexperience.com/healthz         # → {"ok":true}
+curl https://api.cwkexperience.com/contact/healthz # → {"ok":true}
+curl -X POST https://api.cwkexperience.com/waitlist \
   -H "Content-Type: application/json" \
   -d '{"email":"test@example.com"}'             # → {"success":true}
 ```
 
-If `api.houseofcwk.com` is not yet on Cloudflare, add it as a zone first
+If `api.cwkexperience.com` is not yet on Cloudflare, add it as a zone first
 (or as a subdomain of an existing zone). The custom_domain route binding
 will fail until the hostname resolves to a Cloudflare zone you control.
 
@@ -114,7 +114,7 @@ Actions tab — a `workflow_dispatch` run should appear within seconds.
 
 ## 7. Seeding initial content
 
-In Studio (https://houseofcwk.com/studio after first deploy, or
+In Studio (https://cwkexperience.com/studio after first deploy, or
 http://localhost:4321/studio locally):
 
 1. Create the **Site Settings** singleton (nav, footer, default SEO).
@@ -158,7 +158,7 @@ Each publish fires the webhook → GitHub Actions → site rebuilds in ~2 min.
   static `dist/studio/index.html` for any `/studio/*` path via the
   `_redirects` rewrite rule.
 - **API** (Cloudflare Worker `cwk-api-prod`, source at `workers/api/`):
-  bound to `api.houseofcwk.com`. Routes: `POST /waitlist`, `POST /contact`,
+  bound to `api.cwkexperience.com`. Routes: `POST /waitlist`, `POST /contact`,
   `GET /healthz`, `GET /contact/healthz`. Reuses the KV namespaces from
   the prior waitlist + contact workers so existing entries carry over.
 - **CMS** (Sanity, project `3fsa3jok`, dataset `production`): public-read

--- a/docs/uiflows.md
+++ b/docs/uiflows.md
@@ -79,7 +79,7 @@ The shared design system. Designer-owned. Deliverables: token set (colors, spaci
 
 ### #28 · [RFC-101] T-14 Deployment & DevOps — CI/CD, hosting, env config
 
-No direct UI. Designer impact: confirm any environment-specific UI affordances (e.g. a "preview / staging" banner, feature-flag indicator) and the basic-auth gate that wraps the houseofcwk.com staging domain. Make sure brand assets, favicons, OG images, and 404 / 500 / maintenance screens are designed and shipped as part of the deploy pipeline.
+No direct UI. Designer impact: confirm any environment-specific UI affordances (e.g. a "preview / staging" banner, feature-flag indicator) and the basic-auth gate that wraps the cwkexperience.com staging domain. Make sure brand assets, favicons, OG images, and 404 / 500 / maintenance screens are designed and shipped as part of the deploy pipeline.
 
 ---
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -15,25 +15,25 @@ Pillars: Mind, Body, Soul, Pocket.
 
 ## Core pages
 
-- [Home](https://houseofcwk.com/): The Sports Agent for Entrepreneurs. The infrastructure layer for founders.
-- [About Kris](https://houseofcwk.com/about): Founder Kris San's why and origin story.
-- [Kris's Journey](https://houseofcwk.com/about/journey): Six-chapter picture story from Puerto Rico to Austin.
-- [Side Quests](https://houseofcwk.com/side-quests): Other body of work. Keep Austin Voting, Almost Real Things advisory, Experiential Vending Machine, Life Lessons of a Creative Entrepreneur podcast.
-- [What Player Are You?](https://houseofcwk.com/assessment): Free 2-minute founder archetype assessment.
+- [Home](https://cwkexperience.com/): The Sports Agent for Entrepreneurs. The infrastructure layer for founders.
+- [About Kris](https://cwkexperience.com/about): Founder Kris San's why and origin story.
+- [Kris's Journey](https://cwkexperience.com/about/journey): Six-chapter picture story from Puerto Rico to Austin.
+- [Side Quests](https://cwkexperience.com/side-quests): Other body of work. Keep Austin Voting, Almost Real Things advisory, Experiential Vending Machine, Life Lessons of a Creative Entrepreneur podcast.
+- [What Player Are You?](https://cwkexperience.com/assessment): Free 2-minute founder archetype assessment.
 
 ## The 3 Levels
 
-- [Level 2, Power Ups](https://houseofcwk.com/power-ups): The 21 Power Ups across Brand, Sales, and Presence.
-- [Product preview](https://houseofcwk.com/product): The Personal Leverage OS dashboard preview.
+- [Level 2, Power Ups](https://cwkexperience.com/power-ups): The 21 Power Ups across Brand, Sales, and Presence.
+- [Product preview](https://cwkexperience.com/product): The Personal Leverage OS dashboard preview.
 
 ## Case studies
 
-- [DAWA](https://houseofcwk.com/case-studies/dawa)
-- [Pay The Creators Podcast](https://houseofcwk.com/case-studies/pay-the-creators)
-- [Rob Dial](https://houseofcwk.com/case-studies/rob-dial)
-- [Spraycation](https://houseofcwk.com/case-studies/spraycation)
-- [Stephy Lee](https://houseofcwk.com/case-studies/stephy-lee)
-- [The LAB Miami](https://houseofcwk.com/case-studies/the-lab-miami)
+- [DAWA](https://cwkexperience.com/case-studies/dawa)
+- [Pay The Creators Podcast](https://cwkexperience.com/case-studies/pay-the-creators)
+- [Rob Dial](https://cwkexperience.com/case-studies/rob-dial)
+- [Spraycation](https://cwkexperience.com/case-studies/spraycation)
+- [Stephy Lee](https://cwkexperience.com/case-studies/stephy-lee)
+- [The LAB Miami](https://cwkexperience.com/case-studies/the-lab-miami)
 
 ## Contact
 

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -95,7 +95,7 @@
     font-weight="400"
     fill="rgba(238,240,255,0.38)"
     text-anchor="end"
-  >houseofcwk.com</text>
+  >cwkexperience.com</text>
 
   <!-- Bottom accent bar -->
   <rect x="0" y="626" width="1200" height="4" fill="url(#accentBar)"/>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://houseofcwk.com/sitemap-index.xml
+Sitemap: https://cwkexperience.com/sitemap-index.xml

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -37,25 +37,25 @@ Pillars: Mind, Body, Soul, Pocket.
 
 ## Core pages
 
-- [Home](https://houseofcwk.com/): The Sports Agent for Entrepreneurs. The infrastructure layer for founders.
-- [About Kris](https://houseofcwk.com/about): Founder Kris San's why and origin story.
-- [Kris's Journey](https://houseofcwk.com/about/journey): Six-chapter picture story from Puerto Rico to Austin.
-- [Side Quests](https://houseofcwk.com/side-quests): Other body of work. Keep Austin Voting, Almost Real Things advisory, Experiential Vending Machine, Life Lessons of a Creative Entrepreneur podcast.
-- [What Player Are You?](https://houseofcwk.com/assessment): Free 2-minute founder archetype assessment.
+- [Home](https://cwkexperience.com/): The Sports Agent for Entrepreneurs. The infrastructure layer for founders.
+- [About Kris](https://cwkexperience.com/about): Founder Kris San's why and origin story.
+- [Kris's Journey](https://cwkexperience.com/about/journey): Six-chapter picture story from Puerto Rico to Austin.
+- [Side Quests](https://cwkexperience.com/side-quests): Other body of work. Keep Austin Voting, Almost Real Things advisory, Experiential Vending Machine, Life Lessons of a Creative Entrepreneur podcast.
+- [What Player Are You?](https://cwkexperience.com/assessment): Free 2-minute founder archetype assessment.
 
 ## The 3 Levels
 
-- [Level 2, Power Ups](https://houseofcwk.com/power-ups): The 21 Power Ups across Brand, Sales, and Presence.
-- [Product preview](https://houseofcwk.com/product): The Personal Leverage OS dashboard preview.
+- [Level 2, Power Ups](https://cwkexperience.com/power-ups): The 21 Power Ups across Brand, Sales, and Presence.
+- [Product preview](https://cwkexperience.com/product): The Personal Leverage OS dashboard preview.
 
 ## Case studies
 
-- [DAWA](https://houseofcwk.com/case-studies/dawa)
-- [Pay The Creators Podcast](https://houseofcwk.com/case-studies/pay-the-creators)
-- [Rob Dial](https://houseofcwk.com/case-studies/rob-dial)
-- [Spraycation](https://houseofcwk.com/case-studies/spraycation)
-- [Stephy Lee](https://houseofcwk.com/case-studies/stephy-lee)
-- [The LAB Miami](https://houseofcwk.com/case-studies/the-lab-miami)
+- [DAWA](https://cwkexperience.com/case-studies/dawa)
+- [Pay The Creators Podcast](https://cwkexperience.com/case-studies/pay-the-creators)
+- [Rob Dial](https://cwkexperience.com/case-studies/rob-dial)
+- [Spraycation](https://cwkexperience.com/case-studies/spraycation)
+- [Stephy Lee](https://cwkexperience.com/case-studies/stephy-lee)
+- [The LAB Miami](https://cwkexperience.com/case-studies/the-lab-miami)
 
 ## Contact
 

--- a/scripts/migrate-domain-sanity.mjs
+++ b/scripts/migrate-domain-sanity.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// One-shot Sanity content patch for the houseofcwk.com -> cwkexperience.com
+// domain migration. Updates the two documents that reference the old domain
+// or twitter handle in CMS content.
+//
+// Found by full-export grep (28 docs in production dataset, 2 hits):
+//   - siteSettings.twitterHandle: @houseofcwk -> @cwkexperience
+//   - legalPage-terms.seo.description: Terms governing use of houseofcwk.com... -> cwkexperience.com...
+//
+// Usage:
+//   SANITY_WRITE_TOKEN=sk... node scripts/migrate-domain-sanity.mjs            # dry run
+//   SANITY_WRITE_TOKEN=sk... node scripts/migrate-domain-sanity.mjs --apply    # write
+
+import { createClient } from '@sanity/client';
+
+const PROJECT_ID = process.env.PUBLIC_SANITY_PROJECT_ID ?? '3fsa3jok';
+const DATASET = process.env.PUBLIC_SANITY_DATASET ?? 'production';
+const TOKEN = process.env.SANITY_WRITE_TOKEN;
+const APPLY = process.argv.includes('--apply');
+
+if (APPLY && !TOKEN) {
+  console.error('SANITY_WRITE_TOKEN env var is required for --apply.');
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId: PROJECT_ID,
+  dataset: DATASET,
+  apiVersion: '2024-10-01',
+  token: TOKEN,
+  useCdn: false,
+});
+
+const PATCHES = [
+  {
+    id: 'siteSettings',
+    set: { twitterHandle: '@cwkexperience' },
+    note: 'siteSettings.twitterHandle -> @cwkexperience',
+  },
+  {
+    id: 'legalPage-terms',
+    set: {
+      'seo.description':
+        'Terms governing use of cwkexperience.com and CWK. Experience services.',
+    },
+    note: 'legalPage-terms.seo.description -> cwkexperience.com',
+  },
+];
+
+console.log(`mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}  project=${PROJECT_ID}  dataset=${DATASET}`);
+console.log(`patches: ${PATCHES.length}\n`);
+
+for (const p of PATCHES) {
+  console.log(`- ${p.note}`);
+  for (const [path, value] of Object.entries(p.set)) {
+    console.log(`    ${path}: ${JSON.stringify(value)}`);
+  }
+  if (APPLY) {
+    let patch = client.patch(p.id);
+    for (const [path, value] of Object.entries(p.set)) {
+      patch = patch.set({ [path]: value });
+    }
+    await patch.commit();
+    console.log('    ✓ committed');
+  }
+}
+
+console.log(`\n${APPLY ? 'done.' : 'dry-run complete. re-run with --apply to write.'}`);

--- a/scripts/seed-sanity.mjs
+++ b/scripts/seed-sanity.mjs
@@ -59,7 +59,7 @@ const SITE_SETTINGS = {
       { _key: 'f-terms', _type: 'footerLink', label: 'Terms', href: '/terms' },
     ],
   },
-  twitterHandle: '@houseofcwk',
+  twitterHandle: '@cwkexperience',
   defaultSeo: {
     title: 'CWK. Experience | The Sports Agent for Entrepreneurs',
     description: 'CWK. is the long-term partner for entrepreneurs. We rep your career, install the operations, and manage your growth, all under one house.',
@@ -292,7 +292,7 @@ const LEGAL_TERMS = {
   updatedAt: '2026-04-01',
   seo: {
     title: 'Terms of Service | CWK. Experience',
-    description: 'Terms governing use of houseofcwk.com and CWK. Experience services.',
+    description: 'Terms governing use of cwkexperience.com and CWK. Experience services.',
     ogType: 'website',
     twitterCard: 'summary_large_image',
     robots: 'index, follow, max-image-preview:large',

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -13,7 +13,7 @@ interface FieldErrors {
 }
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const API_BASE = import.meta.env.PUBLIC_API_BASE_URL ?? 'https://api.houseofcwk.com';
+const API_BASE = import.meta.env.PUBLIC_API_BASE_URL ?? 'https://api.cwkexperience.com';
 const TURNSTILE_SITE_KEY = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY as string | undefined;
 
 const TOPIC_OPTIONS = [

--- a/src/components/WaitlistForm.tsx
+++ b/src/components/WaitlistForm.tsx
@@ -4,7 +4,7 @@ type FormState = 'idle' | 'loading' | 'success' | 'duplicate' | 'invalid' | 'ser
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-const API_BASE = import.meta.env.PUBLIC_API_BASE_URL ?? 'https://api.houseofcwk.com';
+const API_BASE = import.meta.env.PUBLIC_API_BASE_URL ?? 'https://api.cwkexperience.com';
 
 const MESSAGES: Record<FormState, { text: string; color: string } | null> = {
   idle:          null,

--- a/src/lib/seoFallbacks.ts
+++ b/src/lib/seoFallbacks.ts
@@ -2,8 +2,8 @@
 // is empty or unreachable. Every consumer reads from Sanity and falls through
 // to these values when fields are missing.
 
-export const SITE_URL = 'https://houseofcwk.com';
-export const TWITTER_HANDLE = '@houseofcwk';
+export const SITE_URL = 'https://cwkexperience.com';
+export const TWITTER_HANDLE = '@cwkexperience';
 export const DEFAULT_OG_IMAGE = '/og/cwk-default-1200x630.jpg';
 export const LEGACY_OG_IMAGE = '/og-image.png'; // pre-existing default; kept as final fallback
 

--- a/src/pages/case-studies/[slug].astro
+++ b/src/pages/case-studies/[slug].astro
@@ -54,7 +54,7 @@ const pageOgType = cs.seo?.ogType ?? 'article';
 const pageTwitterCard = cs.seo?.twitterCard ?? null;
 const pageRobots = cs.seo?.robots ?? null;
 
-const SITE_URL = import.meta.env.PUBLIC_SITE_URL ?? 'https://houseofcwk.com';
+const SITE_URL = import.meta.env.PUBLIC_SITE_URL ?? 'https://cwkexperience.com';
 const articleJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'Article',

--- a/src/pages/lifestyle-calculator.astro
+++ b/src/pages/lifestyle-calculator.astro
@@ -983,7 +983,7 @@ const pageDescription =
   }
 
   // ── Email me my map ────────────────────────────────────
-  const API_BASE = (import.meta.env.PUBLIC_API_BASE_URL ?? 'https://api.houseofcwk.com') as string;
+  const API_BASE = (import.meta.env.PUBLIC_API_BASE_URL ?? 'https://api.cwkexperience.com') as string;
   const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
   async function handleEmailSubmit(e: Event): Promise<void> {

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -40,7 +40,7 @@ const updatedLabel = data?.updatedAt
         <>
         <div class="prose-section">
           <h2>Information We Collect</h2>
-          <p>We collect the following types of information when you interact with houseofcwk.com:</p>
+          <p>We collect the following types of information when you interact with cwkexperience.com:</p>
           <ul>
             <li><strong>Email addresses</strong> submitted voluntarily via the CWK. Agent+ waitlist form.</li>
             <li><strong>Analytics data</strong> collected through Cloudflare Web Analytics, a privacy-first, cookieless analytics solution that does not track individual users or store personal identifiers.</li>
@@ -88,7 +88,7 @@ const updatedLabel = data?.updatedAt
         <div class="prose-section">
           <h2>Contact</h2>
           <p>
-            If you have questions or concerns about this Privacy Policy or how your data is handled, please contact us at <a href="mailto:kris@houseofcwk.com">kris@houseofcwk.com</a>.
+            If you have questions or concerns about this Privacy Policy or how your data is handled, please contact us at <a href="mailto:kris@cwkexperience.com">kris@cwkexperience.com</a>.
           </p>
         </div>
         </>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -9,7 +9,7 @@ let data: any = null;
 try { data = await sanity.fetch(LEGAL_QUERY, { slug: 'terms' }); } catch { data = null; }
 
 const pageTitle = data?.seo?.title ?? 'Terms of Service | CWK. Experience';
-const pageDescription = data?.seo?.description ?? 'Terms governing use of houseofcwk.com and CWK. Experience services.';
+const pageDescription = data?.seo?.description ?? 'Terms governing use of cwkexperience.com and CWK. Experience services.';
 const heading = data?.title ?? 'Terms of Service';
 const updatedLabel = data?.updatedAt
   ? new Date(data.updatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long' })
@@ -38,7 +38,7 @@ const updatedLabel = data?.updatedAt
         <div class="prose-section">
           <h2>Acceptance</h2>
           <p>
-            By accessing or using houseofcwk.com, you agree to be bound by these Terms of Service and all applicable laws and regulations. If you do not agree with any part of these terms, you may not use this site.
+            By accessing or using cwkexperience.com, you agree to be bound by these Terms of Service and all applicable laws and regulations. If you do not agree with any part of these terms, you may not use this site.
           </p>
         </div>
 
@@ -101,7 +101,7 @@ const updatedLabel = data?.updatedAt
         <div class="prose-section">
           <h2>Contact</h2>
           <p>
-            Questions about these Terms of Service? Reach us at <a href="mailto:kris@houseofcwk.com">kris@houseofcwk.com</a>.
+            Questions about these Terms of Service? Reach us at <a href="mailto:kris@cwkexperience.com">kris@cwkexperience.com</a>.
           </p>
         </div>
         </>

--- a/studio-schemas/objects/seo.ts
+++ b/studio-schemas/objects/seo.ts
@@ -37,7 +37,7 @@ export const seo = defineType({
       type: 'url',
       group: 'core',
       description:
-        'Optional. Leave blank to default to the page\'s own URL on houseofcwk.com.',
+        'Optional. Leave blank to default to the page\'s own URL on cwkexperience.com.',
     }),
     defineField({
       name: 'ogImage',

--- a/studio-schemas/siteSettings.ts
+++ b/studio-schemas/siteSettings.ts
@@ -92,7 +92,7 @@ export const siteSettings = defineType({
       title: 'Twitter / X Handle',
       type: 'string',
       description:
-        'Used for the twitter:site meta tag. Include the leading "@", e.g. @houseofcwk.',
+        'Used for the twitter:site meta tag. Include the leading "@", e.g. @cwkexperience.',
     }),
     defineField({
       name: 'organization',

--- a/workers/api/README.md
+++ b/workers/api/README.md
@@ -1,6 +1,6 @@
 # cwk-api (Cloudflare Worker)
 
-The single API worker for houseofcwk.com. Owns `api.houseofcwk.com` via a
+The single API worker for cwkexperience.com. Owns `api.cwkexperience.com` via a
 Custom Domain binding and dispatches to per-route handlers in
 [`src/handlers/`](./src/handlers/).
 
@@ -55,7 +55,7 @@ npm run typecheck
 wrangler deploy --env production
 ```
 
-If `cwk-waitlist-prod` still owns `api.houseofcwk.com` as a Custom Domain,
+If `cwk-waitlist-prod` still owns `api.cwkexperience.com` as a Custom Domain,
 wrangler will prompt for the reassignment on first deploy — accept it. After
 the new worker is live and verified (see root `workers/api/README.md`
 verification section of the consolidation PR), delete the two old workers:

--- a/workers/api/src/handlers/lifestyleCalculator.ts
+++ b/workers/api/src/handlers/lifestyleCalculator.ts
@@ -181,15 +181,15 @@ function buildUserEmail(summary: ResultSummary): string {
 
         <p style="margin:0 0 18px;font-size:13px;color:#A8A29E;line-height:1.7;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">Want the full map with timeline, tools, skills, and phase roadmap? It is waiting on the calculator. We saved your progress.</p>
 
-        <a href="https://houseofcwk.com/lifestyle-calculator" style="display:inline-block;background:linear-gradient(90deg,#00E5FF,#7B61FF);color:#07090F;font-size:14px;font-weight:700;text-decoration:none;padding:13px 26px;border-radius:8px;letter-spacing:0.2px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">Open my full map &rarr;</a>
+        <a href="https://cwkexperience.com/lifestyle-calculator" style="display:inline-block;background:linear-gradient(90deg,#00E5FF,#7B61FF);color:#07090F;font-size:14px;font-weight:700;text-decoration:none;padding:13px 26px;border-radius:8px;letter-spacing:0.2px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">Open my full map &rarr;</a>
 
       </td></tr>
 
       <!-- Footer -->
       <tr><td style="padding-top:28px;">
         <p style="margin:0 0 6px;font-size:12px;color:#44403C;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">Build. Learn. Earn. Play.</p>
-        <p style="margin:0 0 8px;font-size:12px;color:#44403C;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">&copy; 2026 CWK. LLC. &nbsp;&middot;&nbsp; <a href="https://houseofcwk.com" style="color:#00E5FF;text-decoration:none;">houseofcwk.com</a> &nbsp;&middot;&nbsp; <a href="https://houseofcwk.com/privacy" style="color:#57534E;text-decoration:none;">Privacy</a></p>
-        <p style="margin:0;font-size:11px;color:#292524;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">You received this because you used the Lifestyle Calculator at houseofcwk.com.</p>
+        <p style="margin:0 0 8px;font-size:12px;color:#44403C;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">&copy; 2026 CWK. LLC. &nbsp;&middot;&nbsp; <a href="https://cwkexperience.com" style="color:#00E5FF;text-decoration:none;">cwkexperience.com</a> &nbsp;&middot;&nbsp; <a href="https://cwkexperience.com/privacy" style="color:#57534E;text-decoration:none;">Privacy</a></p>
+        <p style="margin:0;font-size:11px;color:#292524;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">You received this because you used the Lifestyle Calculator at cwkexperience.com.</p>
       </td></tr>
 
     </table>
@@ -218,7 +218,7 @@ function buildUserText(summary: ResultSummary): string {
       ? `${summary.minesActive} active mind ${summary.minesActive === 1 ? 'mine' : 'mines'} flagged. Address the inner work first.`
       : '',
     '',
-    'Open my full map: https://houseofcwk.com/lifestyle-calculator',
+    'Open my full map: https://cwkexperience.com/lifestyle-calculator',
     '',
     '----',
     'Build. Learn. Earn. Play.',
@@ -241,7 +241,7 @@ async function sendUserEmail(env: Env, recipient: string, summary: ResultSummary
       html: buildUserEmail(summary),
       text: buildUserText(summary),
       headers: {
-        'List-Unsubscribe': '<mailto:unsubscribe@houseofcwk.com?subject=unsubscribe>',
+        'List-Unsubscribe': '<mailto:unsubscribe@cwkexperience.com?subject=unsubscribe>',
         'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
       },
     }),

--- a/workers/api/src/handlers/waitlist.ts
+++ b/workers/api/src/handlers/waitlist.ts
@@ -142,7 +142,7 @@ function buildConfirmationEmail(): string {
             </table>
 
             <!-- CTA button -->
-            <a href="https://houseofcwk.com/work"
+            <a href="https://cwkexperience.com/work"
                style="display:inline-block;background:#38B2F6;color:#0A0A0A;
                       font-size:14px;font-weight:700;text-decoration:none;
                       padding:14px 28px;border-radius:8px;letter-spacing:0.2px;
@@ -167,17 +167,17 @@ function buildConfirmationEmail(): string {
                       Helvetica,Arial,sans-serif;">
               &copy; 2026 CWK. LLC. All rights reserved.
               &nbsp;&middot;&nbsp;
-              <a href="https://houseofcwk.com"
-                 style="color:#38B2F6;text-decoration:none;">houseofcwk.com</a>
+              <a href="https://cwkexperience.com"
+                 style="color:#38B2F6;text-decoration:none;">cwkexperience.com</a>
               &nbsp;&middot;&nbsp;
-              <a href="https://houseofcwk.com/privacy"
+              <a href="https://cwkexperience.com/privacy"
                  style="color:#57534E;text-decoration:none;">Privacy</a>
             </p>
             <p style="margin:0 0 4px;font-size:11px;color:#292524;
                       font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',
                       Helvetica,Arial,sans-serif;">
               You received this email because you joined the PLOS waitlist at
-              <a href="https://houseofcwk.com" style="color:#292524;text-decoration:underline;">houseofcwk.com</a>.
+              <a href="https://cwkexperience.com" style="color:#292524;text-decoration:underline;">cwkexperience.com</a>.
             </p>
             <p style="margin:0;font-size:11px;color:#292524;
                       font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',
@@ -211,7 +211,7 @@ async function sendConfirmation(env: Env, recipientEmail: string): Promise<void>
       subject: "You're on the PLOS waitlist | CWK. Experience",
       html: buildConfirmationEmail(),
       headers: {
-        'List-Unsubscribe': '<mailto:unsubscribe@houseofcwk.com?subject=unsubscribe>',
+        'List-Unsubscribe': '<mailto:unsubscribe@cwkexperience.com?subject=unsubscribe>',
         'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
       },
       text: [
@@ -224,7 +224,7 @@ async function sendConfirmation(env: Env, recipientEmail: string): Promise<void>
         '',
         "In the meantime, take a look at the work. See what's possible when infrastructure stops leaking and your business actually scales.",
         '',
-        'See the work: https://houseofcwk.com/work',
+        'See the work: https://cwkexperience.com/work',
         '',
         '----',
         'PLOS · Personal Leverage OS',
@@ -232,9 +232,9 @@ async function sendConfirmation(env: Env, recipientEmail: string): Promise<void>
         '',
         'Build. Learn. Earn. Play.',
         '© 2026 CWK. LLC',
-        'houseofcwk.com',
+        'cwkexperience.com',
         '',
-        'You received this email because you joined the PLOS waitlist at houseofcwk.com.',
+        'You received this email because you joined the PLOS waitlist at cwkexperience.com.',
         'To unsubscribe, reply with "unsubscribe" in the subject line.',
         '',
         'CWK. LLC · 447 Broadway, 2nd FL #2056 · New York, NY 10013',
@@ -298,7 +298,7 @@ function buildTeamNotificationEmail(email: string, joinedAt: string, environment
     <table cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
       <tr><td style="padding:6px 0;font-size:12px;color:#A8A29E;width:110px;">Email</td><td style="padding:6px 0;font-size:13px;color:#EEF0FF;">${safeEmail}</td></tr>
       <tr><td style="padding:6px 0;font-size:12px;color:#A8A29E;">Joined</td><td style="padding:6px 0;font-size:13px;color:#EEF0FF;">${safeJoined}</td></tr>
-      <tr><td style="padding:6px 0;font-size:12px;color:#A8A29E;">Source</td><td style="padding:6px 0;font-size:13px;color:#EEF0FF;">houseofcwk.com</td></tr>
+      <tr><td style="padding:6px 0;font-size:12px;color:#A8A29E;">Source</td><td style="padding:6px 0;font-size:13px;color:#EEF0FF;">cwkexperience.com</td></tr>
       <tr><td style="padding:6px 0;font-size:12px;color:#A8A29E;">Env</td><td style="padding:6px 0;font-size:13px;color:#EEF0FF;">${environment}</td></tr>
     </table>
   </div>
@@ -309,7 +309,7 @@ function buildTeamNotificationEmail(email: string, joinedAt: string, environment
     '========================',
     `Email:  ${email}`,
     `Joined: ${joinedAt}`,
-    'Source: houseofcwk.com',
+    'Source: cwkexperience.com',
     `Env:    ${environment}`,
   ].join('\n');
 

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -1,4 +1,5 @@
-// cwk-api — single Cloudflare Worker serving api.houseofcwk.com.
+// cwk-api — single Cloudflare Worker serving api.cwkexperience.com
+// (api.houseofcwk.com kept as a transitional route during the domain migration).
 // Internally dispatches to per-route handlers in ./handlers/.
 
 import type { Env } from './env';

--- a/workers/api/wrangler.toml
+++ b/workers/api/wrangler.toml
@@ -3,18 +3,20 @@ main = "src/index.ts"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat_v2"]
 
-# The single API worker for houseofcwk.com. Internally routes:
+# The single API worker for cwkexperience.com. Internally routes:
 #   POST /waitlist           -> handlers/waitlist.ts  (confirmation email)
 #   POST /contact            -> handlers/contact.ts   (notification + rate limit + spam)
 #   GET  /google-reviews     -> handlers/googleReviews.ts (Places API + 6h cache)
 #   GET  /healthz            -> { ok: true }
 #   GET  /contact/healthz    -> { ok: true }          (kept for backward compat)
-# Owns api.houseofcwk.com as a Custom Domain in env.production.
+# Owns api.cwkexperience.com as the primary Custom Domain in env.production,
+# with api.houseofcwk.com kept as a transitional route until 301 redirects
+# fully replace any cached references.
 
 [vars]
 ENVIRONMENT       = "preview"
 ALLOWED_ORIGIN    = "https://houseofcwk.pages.dev"
-FROM_EMAIL        = "hello@houseofcwk.com"
+FROM_EMAIL        = "hello@cwkexperience.com"
 FROM_NAME         = "CWK. Experience"
 REPLY_TO_EMAIL    = "hello@cwkexperience.com"
 REPLY_TO_NAME     = "Kris San, CWK."
@@ -43,13 +45,14 @@ preview_id = "3b1956ad390e44409ad62d6fbadf329d"
 [env.production]
 name = "cwk-api-prod"
 routes = [
-  { pattern = "api.houseofcwk.com", custom_domain = true },
+  { pattern = "api.cwkexperience.com", custom_domain = true },
+  { pattern = "api.houseofcwk.com",   custom_domain = true },
 ]
 
 [env.production.vars]
 ENVIRONMENT       = "production"
-ALLOWED_ORIGIN    = "https://houseofcwk.com"
-FROM_EMAIL        = "hello@houseofcwk.com"
+ALLOWED_ORIGIN    = "https://cwkexperience.com"
+FROM_EMAIL        = "hello@cwkexperience.com"
 FROM_NAME         = "CWK. Experience"
 REPLY_TO_EMAIL    = "hello@cwkexperience.com"
 REPLY_TO_NAME     = "Kris San, CWK."

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,25 +4,29 @@ compatibility_date = "2025-01-01"
 
 # Cloudflare Pages serves pure static HTML. No _worker.js, no KV.
 # The APIs (waitlist + contact) live in a single consolidated Worker at
-# workers/api/ and deploy separately to api.houseofcwk.com. See
+# workers/api/ and deploy separately to api.cwkexperience.com. See
 # workers/api/wrangler.toml for the KV bindings and workers/api/README.md
 # for the endpoint map + deploy steps.
 #
 # Values below are public (PUBLIC_* or env labels) — they ship to the browser.
 # Sanity content is fetched at BUILD time in GitHub Actions, so the project
 # id / dataset are injected there as env on the build step (see deploy.yml).
+#
+# Internal CF resource names ("houseofcwk" project, "houseofcwk.pages.dev"
+# preview subdomain) are intentionally retained — only public-facing URLs
+# move to cwkexperience.com.
 
 [vars]
 ENVIRONMENT              = "preview"
 PUBLIC_SITE_URL          = "https://houseofcwk.pages.dev"
 PUBLIC_SANITY_PROJECT_ID = "3fsa3jok"
 PUBLIC_SANITY_DATASET    = "production"
-PUBLIC_API_BASE_URL      = "https://api.houseofcwk.com"
+PUBLIC_API_BASE_URL      = "https://api.cwkexperience.com"
 
 [env.production.vars]
 ENVIRONMENT              = "production"
-PUBLIC_SITE_URL          = "https://houseofcwk.com"
+PUBLIC_SITE_URL          = "https://cwkexperience.com"
 PUBLIC_GTM_ID            = "GTM-MVJ9VXS5"
 PUBLIC_SANITY_PROJECT_ID = "3fsa3jok"
 PUBLIC_SANITY_DATASET    = "production"
-PUBLIC_API_BASE_URL      = "https://api.houseofcwk.com"
+PUBLIC_API_BASE_URL      = "https://api.cwkexperience.com"


### PR DESCRIPTION
Closes #179.

## Summary

Switches the public domain from `houseofcwk.com` to `cwkexperience.com` across SEO config, email senders, user-facing copy, structured data, llms.txt, and supporting docs. Internal Cloudflare resource names (Pages project `houseofcwk`, preview subdomain `houseofcwk.pages.dev`) and the GitHub repo path are intentionally retained.

## Tiers (single PR per decision)

- **Tier 1 — SEO/config**: `astro.config.mjs`, `public/robots.txt`, `src/lib/seoFallbacks.ts`, `wrangler.toml`, `workers/api/wrangler.toml`, `.github/workflows/deploy.yml`, `.env.example`, `.dev.vars.example`
- **Tier 2 — user-facing copy**: waitlist + lifestyle calculator email templates, privacy, terms, case-study slug page, WaitlistForm, ContactForm, Sanity schemas + seed defaults
- **Tier 3 — split-email collapse**: `FROM_EMAIL` → `hello@cwkexperience.com`; `unsubscribe@cwkexperience.com` for List-Unsubscribe headers; `REPLY_TO_EMAIL` and inbox destinations already on cwkexperience.com (verified)
- **Tier 4 — docs**: README, ARCHITECTURE, SANITY_RUNBOOK, DEPLOYMENT_GUIDE, AGENTS, CONTEXT, workers/api/README, page-edit skill, uiflows
- **Assets**: `public/og-image.svg` domain text, `public/llms.txt` regenerated
- **Sanity**: new `scripts/migrate-domain-sanity.mjs` patches the 2 CMS docs that reference the old domain (`siteSettings.twitterHandle`, `legalPage-terms.seo.description`)

## Worker route strategy

The production Worker now binds **both** custom domains during transition:

```toml
routes = [
  { pattern = "api.cwkexperience.com", custom_domain = true },
  { pattern = "api.houseofcwk.com",   custom_domain = true },
]
```

This lets any cached page on `houseofcwk.com` continue to reach the API while the 301 redirect rules propagate. Drop the old route in a follow-up cleanup once monitoring shows zero traffic on `api.houseofcwk.com`.

## Internal CF resources retained (per decision)

- Pages project name: `houseofcwk` — `--project-name` in `deploy.yml` unchanged
- Preview subdomain: `*.houseofcwk.pages.dev` — `PUBLIC_SITE_URL` (preview env) and `ALLOWED_ORIGIN` (preview env) unchanged
- Worker name: `cwk-api` (production: `cwk-api-prod`) — unchanged
- GitHub repo path: `houseofcwk/website` — unchanged

## Verification

- `npx astro check`: 0 errors, 0 warnings (3 pre-existing hints unrelated to this change)
- `tsc --noEmit` (workers/api): clean
- `npm run build`: 22 pages built, sitemap shows `https://cwkexperience.com/...`, robots.txt points at the new sitemap, canonical + og:url + JSON-LD all render with the new domain
- Built site: 49 `cwkexperience.com` references; only Sanity-sourced refs to the old domain remain (twitter:site from `siteSettings.twitterHandle`, terms description) — fixed by running `scripts/migrate-domain-sanity.mjs --apply`

## Test plan

- [ ] **GATE — Resend domain verification**: confirm `cwkexperience.com` is verified in Resend (SPF / DKIM / DMARC) **before merging**, otherwise all transactional email sends will fail silently. This is the only critical pre-req between merge and successful production cutover.
- [ ] Cloudflare Pages: add `cwkexperience.com` and `www.cwkexperience.com` as custom domains on the existing `houseofcwk` Pages project
- [ ] Cloudflare Worker: verify `api.cwkexperience.com` route binds successfully on `cwk-api-prod` deploy
- [ ] Confirm mailboxes deliverable: `hello@`, `kris@`, `waitlist@`, `unsubscribe@cwkexperience.com`
- [ ] Merge → production deploy → smoke-test:
  - Homepage canonical / og:url / JSON-LD show cwkexperience.com
  - Sitemap reachable at `https://cwkexperience.com/sitemap-index.xml`
  - Waitlist signup end-to-end: confirmation email FROM `hello@cwkexperience.com`, all body links + List-Unsubscribe → cwkexperience.com, team copy lands in `hello@cwkexperience.com` inbox
  - Lifestyle calculator submission end-to-end (same checks)
  - Contact form: submission lands in `hello@cwkexperience.com`
  - No CORS errors in browser console on the live site
- [ ] Run `SANITY_WRITE_TOKEN=sk... node scripts/migrate-domain-sanity.mjs --apply` to update the 2 CMS docs (twitter handle + terms description)
- [ ] Enable Cloudflare Bulk Redirects: `houseofcwk.com/*` → `cwkexperience.com/*` (301)
- [ ] Submit Change of Address in Google Search Console; resubmit sitemap from new property
- [ ] Monitor Resend bounce dashboard, Worker tail logs (CORS), and 404 logs for 7 days

## Follow-up (separate issue)

Once monitoring confirms no traffic on `api.houseofcwk.com`, drop the transitional route entry from `workers/api/wrangler.toml` and clean up the related comments.