### PR TITLE
lifestyle calculator polish: roadmap width, drop line, bigger tracker, field gaps

### DIFF
--- a/src/pages/lifestyle-calculator.astro
+++ b/src/pages/lifestyle-calculator.astro
@@ -1800,24 +1800,24 @@ const pageDescription =
     font-style: italic; text-align: center;
   }
 
-  /* Phase roadmap — horizontal 4-step timeline */
+  /* Phase roadmap — horizontal 4-step grid that breaks out of the
+     760px content wrap so cards have room to breathe. The
+     numbered circles still anchor each phase; no connecting line. */
   .lc-phase-grid {
-    display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px;
     position: relative;
     counter-reset: phase;
-  }
-  .lc-phase-grid::before {
-    content: ''; position: absolute;
-    top: 38px; left: 6%; right: 6%; height: 2px;
-    background: linear-gradient(90deg,
-      var(--cyan) 0%, var(--purple) 100%);
-    opacity: 0.32;
-    z-index: 0;
+    /* Break out of .lc-wrap (760px max) to ~1180px on wide screens.
+       Stays visually centered via translateX(-50%). */
+    width: min(1180px, calc(100vw - 32px));
+    left: 50%;
+    transform: translateX(-50%);
   }
   .lc-phase-card {
-    padding: 32px 18px 20px;
+    padding: 36px 22px 24px;
     position: relative; overflow: visible;
     counter-increment: phase;
+    text-align: left;
   }
   .lc-phase-card::before {
     content: counter(phase);
@@ -1831,31 +1831,35 @@ const pageDescription =
     z-index: 1;
   }
   .lc-phase-top {
-    display: flex; flex-direction: column; align-items: center; gap: 6px;
-    margin-bottom: 12px;
-    text-align: center;
+    display: flex; flex-direction: column; align-items: flex-start; gap: 8px;
+    margin-bottom: 14px;
   }
   .lc-phase-badge {
-    font-size: 9px; font-weight: 700; letter-spacing: 0.28em;
+    font-size: 10px; font-weight: 700; letter-spacing: 0.24em;
     text-transform: uppercase; color: var(--pink);
     line-height: 1.4;
   }
   .lc-phase-time {
-    font-size: 9px; font-weight: 600; letter-spacing: 0.08em;
+    font-size: 10px; font-weight: 600; letter-spacing: 0.08em;
     background: rgba(255, 255, 255, 0.06);
     border: 1px solid var(--gb);
     border-radius: 999px; padding: 3px 10px; color: var(--dim);
     white-space: nowrap;
   }
-  .lc-phase-focus { font-size: 13px; font-weight: 700; color: var(--text); line-height: 1.4; margin-bottom: 12px; text-align: center; }
-  .lc-phase-tasks { display: flex; flex-direction: column; gap: 6px; }
+  .lc-phase-focus { font-size: 14px; font-weight: 700; color: var(--text); line-height: 1.45; margin-bottom: 14px; letter-spacing: -0.005em; }
+  .lc-phase-tasks { display: flex; flex-direction: column; gap: 8px; }
   .lc-phase-task {
-    font-size: 11.5px; color: var(--muted); line-height: 1.55;
+    font-size: 12.5px; color: var(--muted); line-height: 1.6;
     padding-left: 14px; position: relative;
   }
   .lc-phase-task::before {
     content: '•'; position: absolute; left: 0; top: -2px;
     color: var(--cyan); font-size: 14px;
+  }
+
+  /* Intermediate widths (tablet): 2x2 grid so cards stay readable. */
+  @media (max-width: 1100px) {
+    .lc-phase-grid { grid-template-columns: 1fr 1fr; }
   }
 
   /* Mine result card */

--- a/src/pages/lifestyle-calculator.astro
+++ b/src/pages/lifestyle-calculator.astro
@@ -121,7 +121,7 @@ const pageDescription =
           </div>
         </div>
 
-        <div class="lc-field-grid" style="margin-top:2px;">
+        <div class="lc-field-grid">
           <div class="lc-field-group">
             <label class="lc-field-label" for="lc-hours-week">Hours a week you can invest</label>
             <input type="number" id="lc-hours-week" placeholder="15" min="1" max="168" inputmode="numeric" />
@@ -1157,18 +1157,19 @@ const pageDescription =
   }
 
   /* Board indicator */
-  .lc-board-wrap { padding: 4px 0 36px; }
+  .lc-board-wrap { padding: 36px 0 44px; }
   .lc-board { display: flex; align-items: center; }
   .lc-board-sq {
-    width: 38px; height: 38px; flex-shrink: 0;
+    width: 52px; height: 52px; flex-shrink: 0;
     background: var(--glass);
     border: 1px solid var(--gb);
-    border-radius: 8px;
+    border-radius: 10px;
     display: flex; align-items: center; justify-content: center;
-    font-size: 10px; font-weight: 700; color: var(--dim);
+    font-size: 14px; font-weight: 700; color: var(--dim);
+    letter-spacing: -0.01em;
     position: relative; transition: all 0.4s ease;
   }
-  .lc-board-conn { height: 1px; flex: 1; background: var(--gb); min-width: 6px; }
+  .lc-board-conn { height: 1px; flex: 1; background: var(--gb); min-width: 8px; }
   .lc-board-sq.is-done {
     background: rgba(0, 229, 255, 0.06);
     border-color: rgba(0, 229, 255, 0.3);
@@ -1188,7 +1189,7 @@ const pageDescription =
     box-shadow: 0 0 8px var(--cyan), 0 0 18px rgba(0, 229, 255, 0.5);
     animation: lc-pulse 2s ease-in-out infinite;
   }
-  .lc-board-sq.is-goal { background: rgba(123, 97, 255, 0.06); border-color: rgba(123, 97, 255, 0.3); color: var(--purple); font-size: 14px; }
+  .lc-board-sq.is-goal { background: rgba(123, 97, 255, 0.06); border-color: rgba(123, 97, 255, 0.3); color: var(--purple); font-size: 18px; }
   @keyframes lc-pulse {
     0%, 100% { transform: translateX(-50%) scale(1); opacity: 1; }
     50%      { transform: translateX(-50%) scale(1.5); opacity: 0.6; }
@@ -1390,7 +1391,8 @@ const pageDescription =
   .lc-arch-card.is-selected .lc-arch-check { opacity: 1; transform: scale(1); }
 
   /* ── Step 2: Fields ─────────────────────────────────── */
-  .lc-field-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+  .lc-field-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 14px; }
+  .lc-field-grid:last-of-type { margin-bottom: 0; }
   .lc-field-group {
     padding: 16px 18px;
     display: flex; flex-direction: column; gap: 8px;
@@ -2007,7 +2009,11 @@ const pageDescription =
     .lc-player-stats,
     .lc-sub-grid,
     .lc-field-grid { grid-template-columns: 1fr; }
-    .lc-board-sq { width: 32px; height: 32px; font-size: 9px; }
+    .lc-board-wrap { padding: 16px 0 32px; }
+    .lc-board-sq { width: 32px; height: 32px; font-size: 10px; border-radius: 8px; }
+    .lc-board-sq.is-goal { font-size: 13px; }
+    .lc-board-conn { min-width: 4px; }
+    .lc-field-grid { grid-template-columns: 1fr 1fr; gap: 10px; }
     .lc-funnel-total { flex-direction: column; align-items: flex-start; gap: 12px; }
     .lc-funnel-total-num { font-size: 36px; }
     .lc-email-form { flex-direction: column; }


### PR DESCRIPTION
Bundles a few small visual fixes for the lifestyle calculator:

## Phase roadmap (closes #183)
- Cards too thin in 4-col grid because they were squeezed inside the 760px content wrap. Now `.lc-phase-grid` breaks out to `min(1180px, 100vw - 32px)` (centered via `left: 50% + translateX(-50%)`).
- Connecting gradient line removed — read as a stray rule.
- New `max-width: 1100px` media rule collapses to 2x2 before the existing 768px rule collapses to 1col, giving tablets a comfortable 2-col layout.
- Phase cards left-aligned (was centered), 14px focus title, 12.5px bulletpoints.

## Step tracker (top of every question step)
- 36px top padding above the row so it doesn't sit flush against the header.
- Desktop squares 38x38 → 52x52, font 10px → 14px, radius 8px → 10px. Goal star sized up to 18px.
- Mobile tracker stays compact at 32x32 / 10px with 16px top padding.

## Step 03 (The Prize) field grid
- Gap between the 4 input cards: 8px → 14px.
- Removed inline `style="margin-top:2px"` on the second row so spacing is CSS-controlled and consistent between rows.