### PR TITLE
lifestyle calculator: clear persisted state once results render

### DIFF
--- a/src/pages/lifestyle-calculator.astro
+++ b/src/pages/lifestyle-calculator.astro
@@ -475,6 +475,11 @@ const pageDescription =
     if (n === 6) {
       buildResults();
       triggerResultReveals();
+      // The user has completed the flow. Drop the persisted state so a
+      // refresh restarts from step 0 rather than reopening the result
+      // page with stale inputs. State is held in memory until the user
+      // clicks "Run a new idea" (resetAll) or navigates away.
+      clearState();
     }
 
     const wrap = document.querySelector<HTMLElement>('.lc-page');


### PR DESCRIPTION
Closes #185.

In `showStep(n)` when `n === 6`, call the existing `clearState()` helper after results render. localStorage is dropped on completion; in-memory state stays so the result page (and "Run a new idea") still works. A page refresh after completion now restarts from step 0.

One-line fix: `+5 / -0` in `src/pages/lifestyle-calculator.astro`.

## Verified locally
- `npm run build` — 22 pages clean
- in-flow saveState behavior unchanged (steps 0-5 still resume on refresh)
- step 6 mounting now removes `cwk:lifestyle-calculator:v1` from localStorage