### PR TITLE
lifestyle calculator + workers: surface email failures, repoint Tour CWK HQ to Calendly

### DIFF
--- a/src/pages/lifestyle-calculator.astro
+++ b/src/pages/lifestyle-calculator.astro
@@ -332,7 +332,7 @@ const pageDescription =
               <span class="lc-path-label lc-path-a-label">PATH A</span>
               <div class="lc-cta-path-title">Tour CWK.<br>Online HQ</div>
               <p class="lc-cta-path-desc">See the full operating system. Community, frameworks, done-for-you infrastructure, and execution support built for founders who are ready to stop figuring it out alone. No pitch. Just a real look inside.</p>
-              <a class="lc-btn-path-a" href="https://cwkexperience.com" target="_blank" rel="noopener">Tour CWK HQ →</a>
+              <a class="lc-btn-path-a" href="https://calendly.com/cwkexperience/experience-tour" target="_blank" rel="noopener">Tour CWK HQ →</a>
             </div>
             <div class="lc-cta-path lc-cta-path-b">
               <span class="lc-path-label lc-path-b-label">PATH B / FOR NEXT TIME</span>

--- a/workers/api/src/handlers/lifestyleCalculator.ts
+++ b/workers/api/src/handlers/lifestyleCalculator.ts
@@ -390,11 +390,19 @@ export async function handleLifestyleCalculatorPost(
   }
 
   if (env.RESEND_API) {
-    ctx.waitUntil(sendUserEmail(env, rawEmail, summary).catch(() => {}));
-    ctx.waitUntil(sendTeamEmail(env, rawEmail, summary, state).catch(() => {}));
+    ctx.waitUntil(sendUserEmail(env, rawEmail, summary).catch((e) => {
+      console.error('[lifestyleCalculator] sendUserEmail failed:', e instanceof Error ? e.message : e);
+    }));
+    ctx.waitUntil(sendTeamEmail(env, rawEmail, summary, state).catch((e) => {
+      console.error('[lifestyleCalculator] sendTeamEmail failed:', e instanceof Error ? e.message : e);
+    }));
+  } else {
+    console.warn('[lifestyleCalculator] RESEND_API not set — skipping email sends. Set the secret with: wrangler secret put RESEND_API --env production');
   }
   if (env.SLACK_WEBHOOK_URL) {
-    ctx.waitUntil(sendSlackNotification(env, rawEmail, summary, state).catch(() => {}));
+    ctx.waitUntil(sendSlackNotification(env, rawEmail, summary, state).catch((e) => {
+      console.error('[lifestyleCalculator] sendSlackNotification failed:', e instanceof Error ? e.message : e);
+    }));
   }
 
   return json({ success: true }, 200, env);

--- a/workers/api/src/handlers/waitlist.ts
+++ b/workers/api/src/handlers/waitlist.ts
@@ -366,11 +366,19 @@ export async function handleWaitlistPost(request: Request, env: Env, ctx: Execut
     // Fire-and-forget side effects — don't block the response on delivery.
     // Each call swallows its own failure so one outage doesn't kill the rest.
     if (env.RESEND_API) {
-      ctx.waitUntil(sendConfirmation(env, rawEmail).catch(() => {}));
-      ctx.waitUntil(sendTeamNotification(env, rawEmail, entry.joinedAt).catch(() => {}));
+      ctx.waitUntil(sendConfirmation(env, rawEmail).catch((e) => {
+        console.error('[waitlist] sendConfirmation failed:', e instanceof Error ? e.message : e);
+      }));
+      ctx.waitUntil(sendTeamNotification(env, rawEmail, entry.joinedAt).catch((e) => {
+        console.error('[waitlist] sendTeamNotification failed:', e instanceof Error ? e.message : e);
+      }));
+    } else {
+      console.warn('[waitlist] RESEND_API not set — skipping confirmation + team-copy emails');
     }
     if (env.SLACK_WEBHOOK_URL) {
-      ctx.waitUntil(sendSlackNotification(env, rawEmail).catch(() => {}));
+      ctx.waitUntil(sendSlackNotification(env, rawEmail).catch((e) => {
+        console.error('[waitlist] sendSlackNotification failed:', e instanceof Error ? e.message : e);
+      }));
     }
 
     return json({ success: true }, 200, env);


### PR DESCRIPTION
Closes #187 and #188.

## What

1. **Workers**: replace every `.catch(() => {})` in waitlist + lifestyle calculator handlers with explicit `console.error` so the next missing-secret or Resend-API-error surfaces in `wrangler tail` and Cloudflare observability instead of silently swallowing. Adds `console.warn` when `env.RESEND_API` is missing.
2. **Frontend**: `Tour CWK HQ →` CTA on the calculator result step now points to `https://calendly.com/cwkexperience/experience-tour` instead of the homepage.

## Why now

Diagnosed that `cwk-api-prod` is missing the `RESEND_API` secret — that's why `efemer@gmail.com` saw 'Sent ✓' but no email landed. Setting the secret is a separate human operational step:

```bash
cd workers/api
npx wrangler secret put RESEND_API --env production
```

This PR is the **observability** companion to that — once the secret is set, any future Resend rejections (rate-limit, domain unverified, address malformed, etc.) will be loud.

## Verification
- `tsc --noEmit` (workers/api): clean
- `npm run build` (site): 22 pages clean
- `grep "\.catch(() => {})" workers/api/src/handlers/` returns nothing in waitlist + lifestyleCalculator after the change