### PR TITLE
header + homepage hero: Lifestyle Calculator becomes the primary CTA

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -22,7 +22,6 @@ const isActive = (path: string) => currentPath === path || currentPath.startsWit
     <!-- Desktop nav links (no icons) -->
     <div class="nav-links">
       <a href="/case-studies"        class:list={['nav-link', { active: isActive('/case-studies') }]}>Case Studies</a>
-      <a href="/lifestyle-calculator" class:list={['nav-link', { active: isActive('/lifestyle-calculator') }]}>Calculator</a>
       <a href="/about"               class:list={['nav-link', { active: isActive('/about') }]}>About</a>
       <a href="/product"             class:list={['nav-link nav-link--soon', { active: isActive('/product') }]}>
         PLOS
@@ -31,7 +30,7 @@ const isActive = (path: string) => currentPath === path || currentPath.startsWit
     </div>
 
     <div class="nav-actions">
-      <a href="/assessment" class:list={['btn btn-primary nav-cta-btn', { active: isActive('/assessment') }]}>What Player Are You? →</a>
+      <a href="/lifestyle-calculator" class:list={['btn btn-primary nav-cta-btn', { active: isActive('/lifestyle-calculator') }]}>Lifestyle Calculator →</a>
     </div>
 
     <!-- Hamburger (mobile only) -->
@@ -80,23 +79,6 @@ const isActive = (path: string) => currentPath === path || currentPath.startsWit
       Case Studies
     </a>
 
-    <a href="/lifestyle-calculator" class:list={['overlay-link', { active: isActive('/lifestyle-calculator') }]}>
-      <span class="overlay-icon" aria-hidden="true">
-        <!-- Calculator icon -->
-        <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <rect x="4" y="2" width="14" height="18" rx="2" stroke="currentColor" stroke-width="1.5"/>
-          <rect x="7" y="5" width="8" height="3" rx="0.5" stroke="currentColor" stroke-width="1.25"/>
-          <circle cx="8" cy="12" r="0.8" fill="currentColor"/>
-          <circle cx="11" cy="12" r="0.8" fill="currentColor"/>
-          <circle cx="14" cy="12" r="0.8" fill="currentColor"/>
-          <circle cx="8" cy="15.5" r="0.8" fill="currentColor"/>
-          <circle cx="11" cy="15.5" r="0.8" fill="currentColor"/>
-          <circle cx="14" cy="15.5" r="0.8" fill="currentColor"/>
-        </svg>
-      </span>
-      Lifestyle Calculator
-    </a>
-
     <a href="/about" class:list={['overlay-link', { active: isActive('/about') }]}>
       <span class="overlay-icon" aria-hidden="true">
         <!-- Person icon -->
@@ -122,15 +104,21 @@ const isActive = (path: string) => currentPath === path || currentPath.startsWit
       <span class="overlay-soon-badge" aria-label="Coming soon">Soon</span>
     </a>
 
-    <a href="/assessment" class:list={['overlay-link overlay-link--cta', { active: isActive('/assessment') }]}>
+    <a href="/lifestyle-calculator" class:list={['overlay-link overlay-link--cta', { active: isActive('/lifestyle-calculator') }]}>
       <span class="overlay-icon" aria-hidden="true">
-        <!-- Diamond / mirror icon -->
+        <!-- Calculator icon -->
         <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M11 2L20 11L11 20L2 11L11 2Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
-          <path d="M11 2v18M2 11h18" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.45"/>
+          <rect x="4" y="2" width="14" height="18" rx="2" stroke="currentColor" stroke-width="1.5"/>
+          <rect x="7" y="5" width="8" height="3" rx="0.5" stroke="currentColor" stroke-width="1.25"/>
+          <circle cx="8" cy="12" r="0.8" fill="currentColor"/>
+          <circle cx="11" cy="12" r="0.8" fill="currentColor"/>
+          <circle cx="14" cy="12" r="0.8" fill="currentColor"/>
+          <circle cx="8" cy="15.5" r="0.8" fill="currentColor"/>
+          <circle cx="11" cy="15.5" r="0.8" fill="currentColor"/>
+          <circle cx="14" cy="15.5" r="0.8" fill="currentColor"/>
         </svg>
       </span>
-      What Player Are You?
+      Lifestyle Calculator
     </a>
 
   </nav>

--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -125,10 +125,10 @@ const { eyebrow, headline, phrases, ctaLabel, subtext } = Astro.props;
       </div>
     )}
     <div class="hero-ctas fade-up fade-up-delay-3">
-      <a href="/assessment" class="btn-hero-primary">
-        <span class="btn-emoji" aria-hidden="true">🪞</span>
-        What Player Are You?
-        <em class="btn-badge">Free · 2 min</em>
+      <a href="/lifestyle-calculator" class="btn-hero-primary">
+        <span class="btn-emoji" aria-hidden="true">🗺️</span>
+        Lifestyle Calculator
+        <em class="btn-badge">Free · 3 min</em>
         <svg class="btn-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>
         </svg>


### PR DESCRIPTION
Closes #190.

## Diff at a glance

**Desktop header**:
- 'Calculator' nav-link → removed
- 'What Player Are You? →' → 'Lifestyle Calculator →' (target: `/lifestyle-calculator`)

**Mobile overlay**:
- Standalone 'Lifestyle Calculator' link → removed (no longer needed; it's the primary CTA)
- 'What Player Are You?' bottom CTA → 'Lifestyle Calculator' (calculator icon)

**Homepage hero**:
- '🪞 What Player Are You? · Free · 2 min →' → '🗺️ Lifestyle Calculator · Free · 3 min →'

`/assessment` is still reachable via the Player X-Ray section on case-study pages, the contact page alt-link, the footer, and direct URL.

## Verification
- `npm run build` clean (22 pages)
- 2 files changed, +16 / -28