### PR TITLE
CWK auth pages + entitlement gate on Lifestyle Calculator (#218–#222)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # ── Public (browser-exposed) ────────────────────────────────────────────────
 PUBLIC_SITE_URL=https://cwkexperience.com
+# PLOS app origin — auth + entitlement + checkout APIs (EPIC auth-monetization).
+# Shares the .cwkexperience.com session cookie with this site.
+PUBLIC_PLOS_BASE_URL=https://app.cwkexperience.com
 PUBLIC_CF_ANALYTICS_TOKEN=
 # Google Tag Manager — omit to disable tracking (local dev, previews)
 PUBLIC_GTM_ID=

--- a/src/components/AuthFlow.tsx
+++ b/src/components/AuthFlow.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from 'react';
+import { otpStart, otpVerify, googleSignInUrl, me } from '../lib/plosAuth';
+import { track } from '../lib/analytics';
+
+/**
+ * AuthFlow — EPIC auth-monetization (#219).
+ *
+ * CWK-branded passwordless sign-in island used by /login. Email → 6-digit code
+ * (in-page) or Continue with Google (full redirect). On success, redirects to
+ * `returnUrl`. New emails are provisioned + flagged signup_source='cwk' by PLOS;
+ * existing PLOS users sign into the same account.
+ */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const C = {
+  bg: '#0B0E18',
+  border: 'rgba(0,229,255,0.18)',
+  text: '#EEF0FF',
+  muted: '#A8A29E',
+  cyan: '#00E5FF',
+  violet: '#7B61FF',
+  danger: '#FB3079',
+};
+
+function resolveReturnUrl(explicit?: string): string {
+  if (explicit) return explicit;
+  if (typeof window !== 'undefined') {
+    const q = new URL(window.location.href).searchParams.get('return');
+    if (q) return q;
+  }
+  return '/';
+}
+
+export default function AuthFlow({ returnUrl: returnUrlProp }: { returnUrl?: string }) {
+  const returnUrl = useMemo(() => resolveReturnUrl(returnUrlProp), [returnUrlProp]);
+  const [stage, setStage] = useState<'email' | 'code'>('email');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  // Already signed in? Skip straight to the return target.
+  useEffect(() => {
+    let alive = true;
+    void me().then((r) => {
+      if (alive && r.authenticated) window.location.assign(returnUrl);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [returnUrl]);
+
+  async function requestCode(e: React.FormEvent) {
+    e.preventDefault();
+    if (!EMAIL_RE.test(email)) {
+      setMsg('Enter a valid email.');
+      return;
+    }
+    setBusy(true);
+    setMsg(null);
+    await otpStart(email, 'code', returnUrl);
+    track('cwk_auth_code_requested', {});
+    setBusy(false);
+    setStage('code');
+    setMsg('We sent a 6-digit code. Check your inbox.');
+  }
+
+  async function submitCode(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setMsg(null);
+    const res = await otpVerify(email, code.trim());
+    setBusy(false);
+    if (res.ok) {
+      track('cwk_auth_signed_in', { is_new: Boolean(res.isNew) });
+      window.location.assign(returnUrl);
+    } else {
+      setMsg('That code is invalid or expired. Try again.');
+    }
+  }
+
+  function continueWithGoogle() {
+    track('cwk_auth_google_started', {});
+    window.location.assign(googleSignInUrl(returnUrl));
+  }
+
+  return (
+    <div
+      style={{
+        maxWidth: 420,
+        margin: '0 auto',
+        background: C.bg,
+        border: `1px solid ${C.border}`,
+        borderRadius: 14,
+        padding: '36px 32px',
+        fontFamily:
+          "-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif",
+        color: C.text,
+      }}
+    >
+      <p
+        style={{
+          margin: '0 0 8px',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: 2.5,
+          textTransform: 'uppercase',
+          color: C.cyan,
+        }}
+      >
+        CWK · Sign in
+      </p>
+      <h1 style={{ margin: '0 0 18px', fontSize: 24, fontWeight: 800, letterSpacing: -0.5 }}>
+        {stage === 'email' ? 'Sign in or create your account' : 'Enter your code'}
+      </h1>
+
+      {stage === 'email' ? (
+        <form onSubmit={requestCode}>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="your@email.com"
+            autoComplete="email"
+            style={inputStyle}
+            required
+          />
+          <button type="submit" disabled={busy} style={primaryBtn}>
+            {busy ? 'Sending…' : 'Email me a code →'}
+          </button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, margin: '18px 0' }}>
+            <span style={{ flex: 1, height: 1, background: 'rgba(255,255,255,0.08)' }} />
+            <span style={{ fontSize: 11, color: C.muted }}>or</span>
+            <span style={{ flex: 1, height: 1, background: 'rgba(255,255,255,0.08)' }} />
+          </div>
+          <button type="button" onClick={continueWithGoogle} style={ghostBtn}>
+            Continue with Google
+          </button>
+        </form>
+      ) : (
+        <form onSubmit={submitCode}>
+          <input
+            inputMode="numeric"
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            placeholder="123456"
+            autoComplete="one-time-code"
+            style={{ ...inputStyle, letterSpacing: 8, fontSize: 20, textAlign: 'center' }}
+            required
+          />
+          <button type="submit" disabled={busy || code.length < 6} style={primaryBtn}>
+            {busy ? 'Verifying…' : 'Verify & continue →'}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setStage('email');
+              setCode('');
+              setMsg(null);
+            }}
+            style={{ ...ghostBtn, marginTop: 10 }}
+          >
+            Use a different email
+          </button>
+        </form>
+      )}
+
+      {msg && <p style={{ margin: '14px 0 0', fontSize: 13, color: C.muted }}>{msg}</p>}
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  boxSizing: 'border-box',
+  background: '#07090F',
+  border: '1px solid rgba(255,255,255,0.12)',
+  borderRadius: 8,
+  padding: '12px 14px',
+  color: '#EEF0FF',
+  fontSize: 15,
+  marginBottom: 12,
+};
+
+const primaryBtn: React.CSSProperties = {
+  width: '100%',
+  background: `linear-gradient(90deg,${C.cyan},${C.violet})`,
+  color: '#07090F',
+  fontWeight: 700,
+  fontSize: 14,
+  border: 'none',
+  borderRadius: 8,
+  padding: '13px 0',
+  cursor: 'pointer',
+};
+
+const ghostBtn: React.CSSProperties = {
+  width: '100%',
+  background: 'transparent',
+  color: '#EEF0FF',
+  fontWeight: 600,
+  fontSize: 14,
+  border: '1px solid rgba(255,255,255,0.16)',
+  borderRadius: 8,
+  padding: '12px 0',
+  cursor: 'pointer',
+};

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -28,8 +28,26 @@ const isActive = (path: string) => currentPath === path || currentPath.startsWit
     </div>
 
     <div class="nav-actions">
+      <!-- EPIC auth-monetization (#222): auth affordance. JS swaps the label to
+           the account email when a shared PLOS session is present. -->
+      <a href="/login" id="nav-auth-link" class:list={['nav-link', { active: isActive('/login') }]} data-cwk-auth>Log in</a>
       <a href="/lifestyle-calculator" class:list={['btn btn-primary nav-cta-btn', { active: isActive('/lifestyle-calculator') }]}>Lifestyle Calculator →</a>
     </div>
+
+    <script>
+      // Reflect auth state in the header without blocking render.
+      import { me } from '../lib/plosAuth';
+      const link = document.getElementById('nav-auth-link') as HTMLAnchorElement | null;
+      if (link) {
+        void me().then((r) => {
+          if (r.authenticated && r.user) {
+            link.textContent = 'Account';
+            link.href = '/account';
+            link.title = r.user.email;
+          }
+        });
+      }
+    </script>
 
     <!-- Hamburger (mobile only) -->
     <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false">

--- a/src/lib/gate.ts
+++ b/src/lib/gate.ts
@@ -1,0 +1,46 @@
+/**
+ * Reusable feature gate — EPIC auth-monetization (#220).
+ *
+ * Model: one free run per browser (tracked in localStorage), then a one-time
+ * payment unlocks the feature for good. Paid entitlement is server-authoritative
+ * (PLOS), so a logged-in payer is never blocked even after clearing storage.
+ *
+ * Any gated CWK page reuses this by passing its own feature key.
+ */
+import { getFeatures } from './plosEntitlements';
+
+export function freeRunKey(featureKey: string): string {
+  return `cwk:gate:freeRunUsed:${featureKey}`;
+}
+
+export function isFreeRunUsed(featureKey: string): boolean {
+  try {
+    return localStorage.getItem(freeRunKey(featureKey)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function markFreeRunUsed(featureKey: string): void {
+  try {
+    localStorage.setItem(freeRunKey(featureKey), '1');
+  } catch {
+    /* storage unavailable — gate degrades to always-allow, acceptable */
+  }
+}
+
+export interface GateState {
+  /** Server-authoritative: user has paid for this feature. */
+  entitled: boolean;
+  /** This browser already consumed its free run. */
+  freeRunUsed: boolean;
+  /** True when the run must be paid for before use (free run spent, not paid). */
+  blocked: boolean;
+}
+
+export async function evaluateGate(featureKey: string): Promise<GateState> {
+  const features = await getFeatures();
+  const entitled = features.includes(featureKey);
+  const freeRunUsed = isFreeRunUsed(featureKey);
+  return { entitled, freeRunUsed, blocked: !entitled && freeRunUsed };
+}

--- a/src/lib/plosAuth.ts
+++ b/src/lib/plosAuth.ts
@@ -1,0 +1,89 @@
+/**
+ * PLOS auth client — EPIC auth-monetization (#218).
+ *
+ * Thin wrappers over the PLOS account API (app.cwkexperience.com). All calls
+ * are credentialed so the shared `.cwkexperience.com` session cookie rides
+ * along (CWK and PLOS are same-site). Used by the CWK login/account UI.
+ */
+
+export const PLOS_BASE = (
+  import.meta.env.PUBLIC_PLOS_BASE_URL ?? 'https://app.cwkexperience.com'
+).replace(/\/$/, '');
+
+export interface MeUser {
+  id: string;
+  email: string;
+  name: string | null;
+  role: string;
+  isAdmin: boolean;
+  signupSource: string;
+  workspaceId: string;
+}
+
+export interface MeResult {
+  authenticated: boolean;
+  user?: MeUser;
+}
+
+async function postJson<T>(path: string, body: unknown): Promise<{ status: number; data: T }> {
+  const res = await fetch(`${PLOS_BASE}${path}`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = (await res.json().catch(() => ({}))) as T;
+  return { status: res.status, data };
+}
+
+/** Current auth state via the shared cookie. */
+export async function me(): Promise<MeResult> {
+  try {
+    const res = await fetch(`${PLOS_BASE}/api/account/me`, { credentials: 'include' });
+    if (!res.ok) return { authenticated: false };
+    return (await res.json()) as MeResult;
+  } catch {
+    return { authenticated: false };
+  }
+}
+
+export type OtpMode = 'code' | 'link';
+
+/** Request a 6-digit code or magic link. Always resolves (no enumeration). */
+export async function otpStart(
+  email: string,
+  mode: OtpMode = 'code',
+  returnUrl?: string,
+): Promise<{ ok: boolean }> {
+  const { status } = await postJson('/api/account/otp/start', { email, mode, returnUrl });
+  return { ok: status === 200 };
+}
+
+export interface OtpVerifyResult {
+  ok: boolean;
+  isNew?: boolean;
+  error?: string;
+}
+
+/** Verify a 6-digit code; on success the response sets the session cookie. */
+export async function otpVerify(email: string, code: string): Promise<OtpVerifyResult> {
+  const { status, data } = await postJson<{ ok?: boolean; isNew?: boolean; error?: string }>(
+    '/api/account/otp/verify',
+    { email, code },
+  );
+  if (status === 200 && data.ok) return { ok: true, isNew: data.isNew };
+  return { ok: false, error: data.error ?? `error_${status}` };
+}
+
+/** URL that begins the Google OAuth flow (full redirect), returning to `returnUrl`. */
+export function googleSignInUrl(returnUrl: string): string {
+  const u = new URL(`${PLOS_BASE}/api/account/google-start`);
+  u.searchParams.set('returnUrl', returnUrl);
+  return u.toString();
+}
+
+export async function logout(): Promise<void> {
+  await fetch(`${PLOS_BASE}/api/account/logout`, { method: 'POST', credentials: 'include' }).catch(
+    () => undefined,
+  );
+}

--- a/src/lib/plosEntitlements.ts
+++ b/src/lib/plosEntitlements.ts
@@ -1,0 +1,86 @@
+/**
+ * PLOS entitlements client — EPIC auth-monetization (#218).
+ *
+ * Feature-keyed gating + Stripe checkout against the PLOS API. Reusable by any
+ * gated CWK page: pass a feature key (e.g. 'lifestyle-calculator').
+ */
+import { PLOS_BASE } from './plosAuth';
+
+/** Active feature keys for the signed-in user (empty when unauthenticated). */
+export async function getFeatures(): Promise<string[]> {
+  try {
+    const res = await fetch(`${PLOS_BASE}/api/v1/entitlements`, { credentials: 'include' });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { features?: string[] };
+    return Array.isArray(data.features) ? data.features : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function hasFeature(featureKey: string): Promise<boolean> {
+  const features = await getFeatures();
+  return features.includes(featureKey);
+}
+
+export interface GatedProductInfo {
+  slug: string;
+  name: string;
+  description: string | null;
+  amount: string | number | null;
+  currency: string;
+  billingMode: string;
+}
+
+/** The active product gating a feature (for the paywall UI). Null if none. */
+export async function getProductByFeature(featureKey: string): Promise<GatedProductInfo | null> {
+  try {
+    const res = await fetch(
+      `${PLOS_BASE}/api/v1/gated-products/by-feature/${encodeURIComponent(featureKey)}`,
+      { credentials: 'include' },
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as { product?: GatedProductInfo | null };
+    return data.product ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export interface CheckoutResult {
+  url?: string;
+  entitled?: boolean;
+  error?: string;
+}
+
+/** Start a Stripe Checkout for a product; caller redirects to `url`. */
+export async function startCheckout(
+  productSlug: string,
+  returnUrl: string,
+): Promise<CheckoutResult> {
+  try {
+    const res = await fetch(`${PLOS_BASE}/api/v1/checkout`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ productSlug, returnUrl }),
+    });
+    const data = (await res.json().catch(() => ({}))) as CheckoutResult;
+    if (!res.ok) return { error: data.error ?? `error_${res.status}` };
+    return data;
+  } catch {
+    return { error: 'network' };
+  }
+}
+
+/** Format a price for display (best-effort). */
+export function formatPrice(amount: string | number | null, currency: string): string {
+  if (amount == null || amount === '') return '';
+  const n = Number(amount);
+  if (Number.isNaN(n)) return String(amount);
+  try {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(n);
+  } catch {
+    return `${currency} ${n}`;
+  }
+}

--- a/src/pages/account.astro
+++ b/src/pages/account.astro
@@ -1,0 +1,59 @@
+---
+import Base from '../layouts/Base.astro';
+
+const pageTitle = 'Your account | CWK. Experience';
+const pageDescription = 'Manage your CWK account and purchases.';
+---
+
+<Base title={pageTitle} description={pageDescription}>
+  <section style="min-height:60vh;max-width:560px;margin:0 auto;padding:64px 16px;">
+    <p style="font-size:11px;font-weight:700;letter-spacing:2.5px;text-transform:uppercase;color:#00E5FF;margin:0 0 8px;">Account</p>
+    <h1 style="margin:0 0 24px;font-size:28px;font-weight:800;letter-spacing:-0.5px;color:#EEF0FF;">Your account</h1>
+    <div
+      id="acct-card"
+      style="background:#0B0E18;border:1px solid rgba(0,229,255,0.18);border-radius:14px;padding:28px;color:#EEF0FF;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;"
+    >
+      <p id="acct-loading" style="color:#A8A29E;margin:0;">Loading…</p>
+    </div>
+  </section>
+</Base>
+
+<script>
+  // EPIC auth-monetization (#221): minimal account view — email + purchases + logout.
+  import { me, logout } from '../lib/plosAuth';
+  import { getFeatures } from '../lib/plosEntitlements';
+
+  const FEATURE_LABELS: Record<string, string> = {
+    'lifestyle-calculator': 'Lifestyle Calculator — unlimited',
+  };
+
+  function esc(s: string): string {
+    return s.replace(/[<>&"]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;' }[c] as string));
+  }
+
+  (async () => {
+    const card = document.getElementById('acct-card');
+    if (!card) return;
+    const auth = await me();
+    if (!auth.authenticated || !auth.user) {
+      window.location.replace(`/login?return=${encodeURIComponent('/account')}`);
+      return;
+    }
+    const features = await getFeatures();
+    const purchases = features.length
+      ? features.map((f) => `<li style="margin:0 0 6px;">${esc(FEATURE_LABELS[f] ?? f)}</li>`).join('')
+      : '<li style="color:#A8A29E;list-style:none;margin-left:-20px;">No purchases yet.</li>';
+
+    card.innerHTML = `
+      <p style="margin:0 0 4px;font-size:12px;color:#A8A29E;">Signed in as</p>
+      <p style="margin:0 0 22px;font-size:16px;font-weight:600;">${esc(auth.user.email)}</p>
+      <p style="margin:0 0 8px;font-size:11px;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:#00E5FF;">Purchases</p>
+      <ul style="margin:0 0 24px;padding-left:20px;font-size:14px;line-height:1.6;">${purchases}</ul>
+      <button id="acct-logout" style="background:transparent;color:#EEF0FF;border:1px solid rgba(255,255,255,0.16);border-radius:8px;padding:11px 18px;font-weight:600;font-size:13px;cursor:pointer;">Log out</button>`;
+
+    document.getElementById('acct-logout')?.addEventListener('click', async () => {
+      await logout();
+      window.location.assign('/');
+    });
+  })();
+</script>

--- a/src/pages/auth/callback.astro
+++ b/src/pages/auth/callback.astro
@@ -1,0 +1,28 @@
+---
+import Base from '../../layouts/Base.astro';
+
+const pageTitle = 'Signing you in… | CWK. Experience';
+const pageDescription = 'Completing sign-in.';
+---
+
+<Base title={pageTitle} description={pageDescription}>
+  <section style="min-height:60vh;display:flex;align-items:center;justify-content:center;padding:64px 16px;">
+    <p style="color:#A8A29E;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">
+      Completing sign-in…
+    </p>
+  </section>
+</Base>
+
+<script>
+  // EPIC auth-monetization (#219): generic landing for Google / magic-link
+  // returns. PLOS has already set the shared cookie; confirm via /me, then
+  // forward to the requested return target (default home).
+  import { me } from '../../lib/plosAuth';
+
+  const params = new URL(window.location.href).searchParams;
+  const target = params.get('return') || '/';
+  (async () => {
+    await me().catch(() => undefined);
+    window.location.replace(target);
+  })();
+</script>

--- a/src/pages/lifestyle-calculator.astro
+++ b/src/pages/lifestyle-calculator.astro
@@ -1254,6 +1254,125 @@ const pageDescription =
   showStep(currentStep);
 </script>
 
+<!-- ── EPIC auth-monetization (#220): one-free-run-then-pay gate ─────────────
+     Self-contained module: works off the DOM + localStorage + PLOS APIs, so it
+     needs no access to the calculator script's internals. -->
+<script>
+  import { me } from '../lib/plosAuth';
+  import { getProductByFeature, startCheckout, formatPrice } from '../lib/plosEntitlements';
+  import { evaluateGate, markFreeRunUsed } from '../lib/gate';
+  import { track } from '../lib/analytics';
+
+  const FEATURE = 'lifestyle-calculator';
+  const PRODUCT = 'lifestyle-calculator';
+
+  function currentUrlClean(): string {
+    const u = new URL(window.location.href);
+    u.searchParams.delete('checkout');
+    u.searchParams.delete('auth_error');
+    return u.toString();
+  }
+
+  // ── Paywall overlay ──────────────────────────────────────────────────────
+  function buildOverlay(opts: { priceLabel: string; note?: string }): HTMLElement {
+    const wrap = document.createElement('div');
+    wrap.id = 'lc-paywall';
+    wrap.setAttribute(
+      'style',
+      'position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;' +
+        'background:rgba(7,9,15,0.92);backdrop-filter:blur(6px);padding:24px;',
+    );
+    const price = opts.priceLabel ? `<div style="font-size:30px;font-weight:800;color:#EEF0FF;margin:4px 0 14px;">${opts.priceLabel}<span style="font-size:13px;color:#A8A29E;font-weight:600;"> · one-time</span></div>` : '';
+    const note = opts.note
+      ? `<p style="margin:0 0 14px;font-size:13px;color:#FB3079;">${opts.note}</p>`
+      : '';
+    wrap.innerHTML = `
+      <div style="max-width:440px;width:100%;background:#0B0E18;border:1px solid rgba(0,229,255,0.18);border-radius:14px;padding:34px 30px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#EEF0FF;">
+        <p style="margin:0 0 8px;font-size:11px;font-weight:700;letter-spacing:2.5px;text-transform:uppercase;color:#00E5FF;">Lifestyle Calculator</p>
+        <h2 style="margin:0 0 6px;font-size:23px;font-weight:800;letter-spacing:-0.5px;">You've used your free run</h2>
+        <p style="margin:0 0 6px;font-size:14px;color:#A8A29E;line-height:1.6;">Unlock unlimited runs with a one-time payment — re-run every idea, as many times as you want, forever.</p>
+        ${price}
+        ${note}
+        <button id="lc-unlock-btn" style="width:100%;background:linear-gradient(90deg,#00E5FF,#7B61FF);color:#07090F;font-weight:700;font-size:14px;border:none;border-radius:8px;padding:14px 0;cursor:pointer;">Unlock unlimited →</button>
+        <p id="lc-unlock-msg" style="margin:12px 0 0;font-size:12px;color:#A8A29E;min-height:16px;"></p>
+      </div>`;
+    return wrap;
+  }
+
+  function setMsg(text: string): void {
+    const el = document.getElementById('lc-unlock-msg');
+    if (el) el.textContent = text;
+  }
+
+  async function onUnlock(): Promise<void> {
+    setMsg('Checking your account…');
+    track('lc_checkout_started', {});
+    const auth = await me();
+    if (!auth.authenticated) {
+      // Send to sign-in, returning here to finish payment (payment-first).
+      window.location.assign(`/login?return=${encodeURIComponent(currentUrlClean())}`);
+      return;
+    }
+    const res = await startCheckout(PRODUCT, currentUrlClean());
+    if (res.entitled) {
+      window.location.reload();
+      return;
+    }
+    if (res.url) {
+      window.location.assign(res.url);
+      return;
+    }
+    setMsg('Could not start checkout. Please try again.');
+  }
+
+  async function showPaywall(note?: string): Promise<void> {
+    if (document.getElementById('lc-paywall')) return;
+    const product = await getProductByFeature(FEATURE);
+    const priceLabel = product ? formatPrice(product.amount, product.currency) : '';
+    const overlay = buildOverlay({ priceLabel, note });
+    document.body.appendChild(overlay);
+    document.getElementById('lc-unlock-btn')?.addEventListener('click', () => void onUnlock());
+    track('lc_gate_shown', {});
+  }
+
+  // ── Free-run detection: mark used when the RESULT step (#lc-step-6) shows ──
+  function watchCompletion(): void {
+    const step6 = document.getElementById('lc-step-6');
+    if (!step6) return;
+    const obs = new MutationObserver(() => {
+      if (step6.classList.contains('is-active')) markFreeRunUsed(FEATURE);
+    });
+    obs.observe(step6, { attributes: true, attributeFilter: ['class'] });
+    if (step6.classList.contains('is-active')) markFreeRunUsed(FEATURE);
+  }
+
+  // ── Entry ──────────────────────────────────────────────────────────────
+  (async () => {
+    watchCompletion();
+    const params = new URL(window.location.href).searchParams;
+    const checkout = params.get('checkout');
+
+    if (checkout === 'success') {
+      // Webhook may lag a beat — poll entitlement briefly before deciding.
+      for (let i = 0; i < 5; i += 1) {
+        const g = await evaluateGate(FEATURE);
+        if (g.entitled) {
+          track('lc_paid', {});
+          history.replaceState(null, '', currentUrlClean());
+          return; // unlocked — no overlay
+        }
+        await new Promise((r) => setTimeout(r, 1200));
+      }
+      history.replaceState(null, '', currentUrlClean());
+    }
+
+    const gate = await evaluateGate(FEATURE);
+    if (gate.blocked) {
+      await showPaywall(checkout === 'cancel' ? 'Checkout canceled — finish to unlock.' : undefined);
+    }
+  })();
+</script>
+
 <style is:global>
   /* ───────────────────────────────────────────────────────
      Lifestyle Calculator styles. Marked is:global so they

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -1,0 +1,13 @@
+---
+import Base from '../layouts/Base.astro';
+import AuthFlow from '../components/AuthFlow';
+
+const pageTitle = 'Sign in | CWK. Experience';
+const pageDescription = 'Sign in or create your CWK account to continue.';
+---
+
+<Base title={pageTitle} description={pageDescription}>
+  <section style="min-height:70vh;display:flex;align-items:center;justify-content:center;padding:64px 16px;">
+    <AuthFlow client:load />
+  </section>
+</Base>


### PR DESCRIPTION
CWK marketing-surface auth + the one-free-run-then-pay gate (EPIC auth-monetization, parent houseofcwk/platform#2). Calls the PLOS API cross-origin (shared .cwkexperience.com cookie).

## Included (issues)
- #218 plosAuth + plosEntitlements clients (credentialed) + PUBLIC_PLOS_BASE_URL
- #219 /login (AuthFlow island: OTP code + Google) + /auth/callback landing
- #220 reusable gate lib + paywall wired into lifestyle-calculator (free run -> pay -> unlimited)
- #221 /account (purchases + logout)
- #222 header Log in / Account affordance

## Validation
- `astro check`: 0 errors
- `astro build`: 26 pages built (incl. /login, /account, /auth/callback, gated calculator)

Live E2E (OTP cross-origin, Stripe pay -> unlock) pending keys/deploy — see platform#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)